### PR TITLE
fix: Correct the dump function to print appropriately

### DIFF
--- a/ork.core/inc/ork/math/cmatrix3.hpp
+++ b/ork.core/inc/ork/math/cmatrix3.hpp
@@ -37,10 +37,10 @@ template <typename T> void Matrix33<T>::setToIdentity() {
 template <typename T> void Matrix33<T>::dump(STRING name) {
   orkprintf("Matrix %p %s\n{	", this, name);
 
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 3; i++) {
 
-    for (int j = 0; j < 4; j++) {
-      orkprintf("%f ", elemXY(i,j));
+    for (int j = 0; j < 3; j++) {
+      orkprintf("%f ", elemYX(i,j));
     }
 
     orkprintf("\n	");

--- a/ork.data/platform_lev2/shaders/glfx/grid.glfx
+++ b/ork.data/platform_lev2/shaders/glfx/grid.glfx
@@ -241,6 +241,12 @@ fragment_shader ps_grid_forward_unlit
   vec4 gout = grid_output(frg_pos.xyz);
   out_clr = gout; 
 }
+fragment_shader ps_grid_forward_unlit_v3
+  : iface_grid_forward_unlit
+  : lib_frg_grid {
+  vec4 gout = grid_output2(frg_pos.xyz);
+  out_clr = gout;
+}
 ///////////////////////////////////////////////////////////////
 fragment_shader ps_grid_forward_lit_mono
   : iface_grid_forward_lit
@@ -341,6 +347,10 @@ technique FWD_UNLIT_NI_MO {
 technique FWD_CT_NM_RI_NI_MO {
   fxconfig=fxcfg_default;
   vf_pass={vs_grid_forward_lit,ps_grid_forward_lit_mono,sb_forward}
+}
+technique FWD_UNLIT_NI_MO_V3 {
+       fxconfig=fxcfg_default;
+       vf_pass={vs_grid_forward_unlit,ps_grid_forward_unlit_v3,sb_forward}
 }
 technique FWD_CT_NM_RI_NI_MO_V2 {
   fxconfig=fxcfg_default;


### PR DESCRIPTION
For a Matrix33 type, the dump function printed a transposed 4x4 matrix. This fix amends that. Also, being a small change, it is coupled together with the change in how the grid looks in Ork Window.