### PR TITLE
Add ability to disable PostFxNodes

### DIFF
--- a/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/NodeCompositor.h
+++ b/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/NodeCompositor.h
@@ -98,6 +98,7 @@ public:
     return nullptr;
   }
 
+  bool _disabled = false;
 private:
   virtual void doGpuInit(lev2::Context* pTARG, int w, int h) = 0;
   virtual void DoRender(CompositorDrawData& drawdata)        = 0;

--- a/ork.lev2/pyext/src/pyext_gfx_compositor.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_compositor.cpp
@@ -261,6 +261,13 @@ void pyinit_gfx_compositor(py::module& module_lev2) {
           .def("gpuInit",[](postnode_user_ptr_t dcnode, ctx_t ctx, int w, int h) {
             dcnode->gpuInit(ctx.get(), w, h);
           })
+          .def_property("disabled", //
+            [](postnode_user_ptr_t dcnode) -> bool {
+              return dcnode->_disabled;
+            },
+            [](postnode_user_ptr_t dcnode, bool disabled) {
+              dcnode->_disabled = disabled;
+            })
           .def_property("shader_path", //
             [](postnode_user_ptr_t dcnode) -> std::string {
               return dcnode->_shader_path;

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/NodeCompositor.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/NodeCompositor.cpp
@@ -65,6 +65,9 @@ NodeCompositingTechnique::NodeCompositingTechnique()
     ////////////////////////////////////////////////////////////////////////////
     size_t num_fx_nodes = _postEffectNodes.size();
     for (auto pfxnode : _postEffectNodes) {
+      if (pfxnode->_disabled) {
+        continue;
+      }
       drawdata._properties["postfx_in"_crcu].set<rtgroup_ptr_t>(render_outg);
       pfxnode->Render(drawdata);
       render_outg = pfxnode->GetOutputGroup();

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/OutputNodeDualMonoVr.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/OutputNodeDualMonoVr.cpp
@@ -284,6 +284,9 @@ compdrawdata_fn_t DualMonoVrOutputNode::createAssembler(nodecompositortechnique_
       ////////////////////////////////////////////////////////////////////////////
       size_t num_fx_nodes = tek->_postEffectNodes.size();
       for (auto pfxnode : tek->_postEffectNodes) {
+        if (pfxnode->_disabled) {
+          continue;
+        }
         drawdata._properties["postfx_in"_crcu].set<rtgroup_ptr_t>(render_outg);
         pfxnode->Render(drawdata);
         render_outg = pfxnode->GetOutputGroup();

--- a/ork.lev2/src/gfx/texman.cpp
+++ b/ork.lev2/src/gfx/texman.cpp
@@ -30,7 +30,7 @@ void TextureSamplingModeData::presetPointAndClamp() {
   _texAddrModeT   = TextureAddressMode::CLAMP;
   _texAddrModeR   = TextureAddressMode::CLAMP;
   _texFiltModeMin = ETextureMinifyFilterMode::NEAREST;
-  _texFiltModeMag = ETextureMagnifyFilterMode::LINEAR;
+  _texFiltModeMag = ETextureMagnifyFilterMode::NEAREST;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add ability to disable `PostCompositingNodes` via a `disabled` property.
As all PostFx nodes are executed by default each frame, disabling allows us to skip execution while keeping the node in the pipeline. For example, this is used to optimize buffer flipping in dual-mono mode without executing nodes that are waiting for their turn.