### PR TITLE
Instanced indexed primitive

### DIFF
--- a/ork.lev2/inc/ork/lev2/gfx/gfxenv_enum.h
+++ b/ork.lev2/inc/ork/lev2/gfx/gfxenv_enum.h
@@ -220,7 +220,7 @@ enum struct BlendingMacro : crc_enum_t {
   CrcEnum(SUBTRACTIVE),       // (SrcClr*0) + (FBClr*(1-SrcColor))
   CrcEnum(ALPHA_SUBTRACTIVE), // (SrcClr*0) + (FBClr*(1-SrcAlpha))
   CrcEnum(MODULATE),          // (SrcClr*0) + (FBClr*(1-SrcAlpha))
-}; 
+};
 
 //////////////////////////////////////
 
@@ -233,7 +233,7 @@ enum struct EDepthTest : crc_enum_t {
   CrcEnum(EQUALS),
   CrcEnum(ALWAYS), // is this the same as off?
 
-}; 
+};
 
 //////////////////////////////////////
 
@@ -276,7 +276,7 @@ enum EShadeModel {
 enum struct EFrontFace : crc_enum_t {
   CrcEnum(CLOCKWISE),
   CrcEnum(COUNTER_CLOCKWISE),
-}; 
+};
 
 enum struct ECullTest : crc_enum_t {
   CrcEnum(OFF),
@@ -289,6 +289,8 @@ enum struct ECullTest : crc_enum_t {
 enum struct EVtxStreamFormat : crc_enum_t {
   CrcEnum(VU16),            // 2 BPV	primarily for texture based sourcing
   CrcEnum(VU32),            // 4 BPV	primarily for texture based sourcing
+
+  CrcEnum(VU32INST),        // 4 BPV	primarily for instanced rendering
 
   CrcEnum(V4T4),            // 8 BPV	2D text (or textured quads) no vtxcolors
   CrcEnum(V4C4),            // 8 BPV	2D Colored

--- a/ork.lev2/inc/ork/lev2/gfx/gfxvtxbuf_structs.h
+++ b/ork.lev2/inc/ork/lev2/gfx/gfxvtxbuf_structs.h
@@ -5,7 +5,7 @@
 // see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
 ////////////////////////////////////////////////////////////////
 
-#pragma once 
+#pragma once
 
 #include <ork/lev2/gfx/gfxenv_enum.h>
 #include <ork/util/endian.h>
@@ -15,33 +15,47 @@ namespace ork::lev2 {
   struct SVtxVU16 { // 4 BPV
 
     U16 _data; // 2
-  
+
     SVtxVU16(U16 d)
         : _data(d)
         {
         }
-  
+
     void EndianSwap() {
     }
-  
+
     constexpr static EVtxStreamFormat meFormat = EVtxStreamFormat::VU16;
   };
 
   struct SVtxVU32 { // 4 BPV
 
     U32 _data; // 2
-  
+
     SVtxVU32(U32 d)
         : _data(d)
         {
         }
-  
+
     void EndianSwap() {
     }
-  
+
     constexpr static EVtxStreamFormat meFormat = EVtxStreamFormat::VU32;
   };
-  
+
+  struct SVtxVU32Inst { // 4 BPV
+
+    U32 _instanceId;
+
+    SVtxVU32Inst(U32 d)
+        : _instanceId(d)
+        {
+        }
+
+    void EndianSwap() {
+    }
+
+    constexpr static EVtxStreamFormat meFormat = EVtxStreamFormat::VU32INST;
+  };
   ///////////////////////////////////////////////////////////////////////////////
 
 struct SVtxV4T4 // 8 BPV	PreXF 2D (all on top)
@@ -140,8 +154,8 @@ struct SVtxV4T4C4 // 8 BPV	PreXF 2D (all on top)
 ///////////////////////////////////////////////////////////////////////////////
 
 struct _VtxV12C4 {
-  float x, y, z; 
-  uint32_t color;   
+  float x, y, z;
+  uint32_t color;
 };
 
 struct VtxV12C4 { // 16BPV

--- a/ork.lev2/inc/ork/lev2/gfx/primitives.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/primitives.inl
@@ -8,4 +8,5 @@
 #pragma once
 #include <ork/lev2/gfx/primitives_cube.inl>
 #include <ork/lev2/gfx/primitives_frustum.inl>
+#include <ork/lev2/gfx/primitives_instanced_indexed.inl>
 #include <ork/lev2/gfx/primitives_points.inl>

--- a/ork.lev2/inc/ork/lev2/gfx/primitives_instanced_indexed.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/primitives_instanced_indexed.inl
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////
+// Orkid Media Engine
+// Copyright 1996-2023, Michael T. Mayers.
+// Distributed under the MIT License.
+// see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+////////////////////////////////////////////////////////////////
+
+#pragma once
+#include <ork/lev2/gfx/scenegraph/scenegraph.h>
+#include <ork/lev2/gfx/fx_pipeline.h>
+#include <ork/lev2/gfx/gfxprimitives.h>
+
+namespace ork::lev2::primitives {
+
+//////////////////////////////////////////////////////////////////////////////
+
+struct InstancedIndexedPrimitive {
+
+  using instance_t         = SVtxVU32Inst;
+  using instance_vb_t      = DynamicVertexBuffer<instance_t>;
+  using instance_vb_ptr_t  = std::shared_ptr<instance_vb_t>;
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  int _num_instances;
+  int _capacity;
+  PrimitiveType _prim_type;
+  instance_vb_ptr_t _instance_vb;
+  idxbufferbase_ptr_t _base_ib;
+  fxpipeline_ptr_t _pipeline;
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  inline InstancedIndexedPrimitive(
+    Context* ctx,
+    std::vector<uint16_t> baseIndices,
+    PrimitiveType prim_type,
+    int max_instances
+  ) {
+    _num_instances = max_instances;
+    _prim_type = prim_type;
+    _capacity  = max_instances;
+    _instance_vb = std::make_shared<instance_vb_t>(max_instances, 0);
+
+    auto gbi = ctx->GBI();
+
+    // Create base index buffer from provided indices
+    size_t base_count = baseIndices.size();
+    _base_ib = std::make_shared<StaticIndexBuffer<uint16_t>>(base_count);
+    auto dst_indices = (uint16_t*) ctx->GBI()->LockIB(*_base_ib, 0, base_count);
+
+    memcpy(dst_indices, baseIndices.data(), base_count * sizeof(uint16_t));
+    ctx->GBI()->UnLockIB(*_base_ib);
+
+    // Create instance vertex buffer
+    _instance_vb = std::make_shared<instance_vb_t>(max_instances, 0);
+    auto dst_instances = (instance_t*) ctx->GBI()->LockVB(*_instance_vb, 0, max_instances);
+
+    for(uint32_t i = 0; i < max_instances; i++) {
+      dst_instances[i]._instanceId = i;
+    }
+    ctx->GBI()->UnLockVB(*_instance_vb);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  inline instance_t* lock(Context* context, int num_instances=0) {
+    if(0==num_instances){
+      _num_instances = _capacity;
+      num_instances = _capacity;
+    }
+    else{
+      _num_instances = num_instances;
+      OrkAssert(num_instances<=_capacity);
+    }
+    return (instance_t*) context->GBI()->LockVB(*_instance_vb, 0, _num_instances);
+  }
+
+  inline void unlock(Context* context) {
+    context->GBI()->UnLockVB(*_instance_vb);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  void renderEML(Context* ctx) {
+    auto gbi = ctx->GBI();
+
+    gbi->DrawInstancedIndexedPrimitiveEML(
+      *_instance_vb,
+      *_base_ib,
+      _prim_type,
+      _num_instances);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  inline scenegraph::drawable_node_ptr_t createNode(
+    std::string named, //
+    scenegraph::layer_ptr_t layer,
+    fxpipeline_ptr_t pipeline
+  ) {
+
+    OrkAssert(pipeline);
+
+    _pipeline = pipeline;
+
+    auto drw = std::make_shared<CallbackDrawable>(nullptr);
+    drw->SetRenderCallback([=](lev2::RenderContextInstData& RCID) { //
+      auto context = RCID.context();
+      _pipeline->wrappedDrawCall(RCID, //
+                                 [this, context]() { //
+                                  this->renderEML(context); //
+                                });
+    });
+    return layer->createDrawableNode(named, drw);
+  }
+};
+
+//////////////////////////////////////////////////////////////////////////////
+
+using instanced_indexed_primitive_ptr_t = std::shared_ptr<InstancedIndexedPrimitive>;
+
+} // namespace ork::lev2::primitives

--- a/ork.lev2/inc/ork/lev2/gfx/primitives_points.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/primitives_points.inl
@@ -31,7 +31,7 @@ struct PointsData {
   pointsdata_ptr_t hsvScaleBias(fvec2 hue, fvec2 sat, fvec2 val) const;
   pointsdata_ptr_t swizzleRGB() const;
   pointsdata_ptr_t stochasticSample(float probability) const;
-  
+
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -185,5 +185,6 @@ using tiled_points_v12c4_t = TiledPointsPrimitive<VtxV12C4>;
 using tiled_points_v12c4_ptr_t = std::shared_ptr<tiled_points_v12c4_t>;
 using points_v12c4_ptr_t = std::shared_ptr<PointsPrimitive<VtxV12C4>>;
 using points_v12t8_ptr_t = std::shared_ptr<PointsPrimitive<VtxV12T8>>;
+using points_vu32_ptr_t = std::shared_ptr<PointsPrimitive<SVtxVU32>>;
 
 } // namespace ork::lev2::primitives

--- a/ork.lev2/pyext/src/pyext_gfx_primitives.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_primitives.cpp
@@ -20,6 +20,7 @@ using shape_t             = pybind11::detail::any_container<ssize_t>;
 
 void pyinit_gfx_primitives_rigid(py::module& module_lev2);
 void pyinit_gfx_primitives_points(py::module& primitives);
+void pyinit_gfx_primitives_instanced_indexed(py::module& primitives);
 void pyinit_gfx_primitives_frustum(py::module& primitives);
 
 void pyinit_primitives(py::module& module_lev2) {
@@ -82,6 +83,7 @@ void pyinit_primitives(py::module& module_lev2) {
   /////////////////////////////////////////////////////////////////////////////////
   pyinit_gfx_primitives_rigid(module_lev2); // todo parent under primitives
   pyinit_gfx_primitives_frustum(primitives);
+  pyinit_gfx_primitives_instanced_indexed(primitives);
   pyinit_gfx_primitives_points(primitives);
 }
 } // namespace ork::lev2

--- a/ork.lev2/pyext/src/pyext_gfx_primitives_instanced_indexed.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_primitives_instanced_indexed.cpp
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////
+// Orkid Media Engine
+// Copyright 1996-2023, Michael T. Mayers.
+// Distributed under the MIT License.
+// see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+////////////////////////////////////////////////////////////////
+
+#include <ork/lev2/config.h>
+
+#include "pyext.inl"
+#include <pybind11/numpy.h>
+#include <ork/lev2/gfx/gfxvtxbuf.inl>
+#include <ork/kernel/memcpy.inl>
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace ork::lev2 {
+
+void pyinit_gfx_primitives_instanced_indexed(py::module& primitives) {
+  auto type_codec = python::pb11_typecodec_t::instance();
+
+  ////////////////////////////////////////////////////////////////////////////////
+  auto instancedprim_type = //
+    py::class_<primitives::InstancedIndexedPrimitive, primitives::instanced_indexed_primitive_ptr_t>(primitives, "InstancedIndexedQuadPrimitive")
+        .def(
+            "create",
+            [](ctx_t& context, int num_instances) -> primitives::instanced_indexed_primitive_ptr_t {
+              std::vector<uint16_t> quad_indices = {0, 1, 2, 3};
+              return std::make_shared<primitives::InstancedIndexedPrimitive>(
+                context.get(), quad_indices, PrimitiveType::TRIANGLESTRIP, num_instances);
+            })
+        .def(
+            "lock",
+            [](primitives::instanced_indexed_primitive_ptr_t prim, ctx_t& context, int num_instances) -> py::array_t<SVtxVU32Inst> {
+              auto buffer = prim->lock(context.get(), num_instances);
+              return py::array_t<SVtxVU32Inst>(prim->_num_instances, buffer, py::none());
+            })
+        .def("unlock", [](primitives::instanced_indexed_primitive_ptr_t prim, ctx_t& context) { return prim->unlock(context.get()); })
+        .def("createNode", createNodeLambdaFromPrimType<primitives::instanced_indexed_primitive_ptr_t>());
+  type_codec->registerStdCodec<primitives::instanced_indexed_primitive_ptr_t>(instancedprim_type);
+}
+
+} // namespace ork::lev2

--- a/ork.lev2/pyext/src/pyext_gfx_primitives_points.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_primitives_points.cpp
@@ -409,6 +409,23 @@ void pyinit_gfx_primitives_points(py::module& primitives) {
                 ;
   type_codec->registerStdCodec<primitives::points_v12t8_ptr_t>(pointsprim_type);
   /////////////////////////////////////////////////////////////////////////////////
+  auto pointsprimu32_type = //
+    py::class_<primitives::PointsPrimitive<SVtxVU32>, primitives::points_vu32_ptr_t>(primitives, "PointsPrimitiveVU32")
+        .def(
+            "create",
+            [](int numpoints) -> primitives::points_vu32_ptr_t {
+              return std::make_shared<primitives::PointsPrimitive<SVtxVU32>>(numpoints);
+            })
+        .def(
+            "lock",
+            [](primitives::points_vu32_ptr_t prim, ctx_t& context, int num_points) -> py::array_t<SVtxVU32> {
+              auto buffer = prim->lock(context.get(), num_points);
+              return py::array_t<SVtxVU32>(prim->_numpoints, buffer, py::none());
+            })
+        .def("unlock", [](primitives::points_vu32_ptr_t prim, ctx_t& context) { return prim->unlock(context.get()); })
+        .def("createNode", createNodeLambdaFromPrimType<primitives::points_vu32_ptr_t>());
+  type_codec->registerStdCodec<primitives::points_vu32_ptr_t>(pointsprim_type);
+  ////////////////////////////////////////////////////////////////////////////////
   auto tiled_pointsprim_type = //
       py::class_<primitives::TiledPointsPrimitive<VtxV12C4>, primitives::tiled_points_v12c4_ptr_t>(
           primitives, "TiledPointsPrimitiveV12C4")

--- a/ork.lev2/pyext/src/pyext_gfx_vtxbuffer.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_vtxbuffer.cpp
@@ -100,6 +100,8 @@ void pyinit_gfx_buffers(py::module& module_lev2) {
 
   PYBIND11_NUMPY_DTYPE(VtxV12C4, x, y, z, color);
   PYBIND11_NUMPY_DTYPE(_VtxV12T8, x, y, z, u, v);
+  PYBIND11_NUMPY_DTYPE(SVtxVU32, _data);
+  PYBIND11_NUMPY_DTYPE(SVtxVU32Inst, _instanceId);
 
 }
 } // namespace ork::lev2 {

--- a/ork.lev2/src/gfx/gfxvtxbuf.cpp
+++ b/ork.lev2/src/gfx/gfxvtxbuf.cpp
@@ -56,6 +56,9 @@ vtxbufferbase_ptr_t VertexBufferBase::CreateVertexBuffer(EVtxStreamFormat eforma
     case EVtxStreamFormat::VU32:
       pvb = _createvb<SVtxVU32>(inumverts, bstatic);
       break;
+    case EVtxStreamFormat::VU32INST:
+      pvb = _createvb<SVtxVU32Inst>(inumverts, bstatic);
+      break;
     case EVtxStreamFormat::V12:
       pvb = _createvb<VtxV12>(inumverts, bstatic);
       break;

--- a/ork.lev2/src/gfx/gl/gl.h
+++ b/ork.lev2/src/gfx/gl/gl.h
@@ -11,16 +11,16 @@
 #include <functional>
 #include <map>
 ///////////////////////////////////////////////////////////////////////////////
-#include <ftxui/dom/node.hpp>      
-#include <ftxui/dom/elements.hpp>  
-#include <ftxui/screen/color.hpp>  
-#include <ftxui/screen/screen.hpp>  
-#include <ftxui/component/component_base.hpp>  
-#include <ftxui/component/component.hpp>  
-#include <ftxui/component/captured_mouse.hpp>  
-#include <ftxui/component/screen_interactive.hpp>  
-#include <ftxui/screen/color_info.hpp>  
-#include <ftxui/screen/terminal.hpp> 
+#include <ftxui/dom/node.hpp>
+#include <ftxui/dom/elements.hpp>
+#include <ftxui/screen/color.hpp>
+#include <ftxui/screen/screen.hpp>
+#include <ftxui/component/component_base.hpp>
+#include <ftxui/component/component.hpp>
+#include <ftxui/component/captured_mouse.hpp>
+#include <ftxui/component/screen_interactive.hpp>
+#include <ftxui/screen/color_info.hpp>
+#include <ftxui/screen/terminal.hpp>
 #include <ork/util/logger.h>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -616,7 +616,7 @@ public:
   bool _SUPPORTS_EXTERNAL_MEMORY_OBJECT = true;
   int _MAX_TEXTURE_IMAGE_UNITS = 0;
   std::string _GL_RENDERER;
-  
+
   std::stack<void*> mDCStack;
   std::stack<void*> mGLRCStack;
 

--- a/ork.lev2/src/gfx/gl/gl_gbi.cpp
+++ b/ork.lev2/src/gfx/gl/gl_gbi.cpp
@@ -361,8 +361,8 @@ void* GlGeometryBufferInterface::LockVB(VertexBufferBase& vtxbuf, int ibase, int
               GL_ARRAY_BUFFER,
               ibasebytes,
               isizebytes,
-              GL_MAP_WRITE_BIT | 
-              GL_MAP_INVALIDATE_RANGE_BIT | 
+              GL_MAP_WRITE_BIT |
+              GL_MAP_INVALIDATE_RANGE_BIT |
               GL_MAP_FLUSH_EXPLICIT_BIT |
               GL_MAP_UNSYNCHRONIZED_BIT); // MAP_UNSYNCHRONIZED_BIT?
           // rVal = glMapBufferRange( GL_ARRAY_BUFFER, ibasebytes, isizebytes, GL_MAP_WRITE_BIT ); // MAP_UNSYNCHRONIZED_BIT?
@@ -517,7 +517,7 @@ void GlGeometryBufferInterface::UnLockVB(const VertexBufferBase& vtxbuf) {
 ///////////////////////////////////////////////////////////////////////////////
 
 void GlGeometryBufferInterface::ReleaseVB(VertexBufferBase& vtxbuf) {
-  vtxbuf._impl = nullptr;  
+  vtxbuf._impl = nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -533,6 +533,7 @@ struct vtx_config {
   const GLenum mType;
   const AttrType _attrtype;
   const int mOffset;
+  const int mDivisor;
   const glslfx::Pass* mPass;
   glslfx::Attribute* mAttr;
 
@@ -562,6 +563,9 @@ struct vtx_config {
         case AttrType::INTEGER:
           glVertexAttribIPointer(mAttr->mLocation, mNu_components, mType, istride, (void*)(uint64_t)mOffset);
           break;
+      }
+      if (mDivisor) {
+        glVertexAttribDivisor(mAttr->mLocation, mDivisor);
       }
       rval = 1 << mAttr->mLocation;
     } else {
@@ -614,38 +618,43 @@ static bool EnableVtxBufComponents(const VertexBufferBase& vtxbuf, const svarp_t
   //////////////////////////////////////////////
   switch (eStrFmt) {
     case lev2::EVtxStreamFormat::VU16: {
-      static vtx_config cfgs[] = {{"POSITION", 1, GL_UNSIGNED_SHORT, AttrType::INTEGER, 0, 0, 0}};
+      static vtx_config cfgs[] = {{"POSITION", 1, GL_UNSIGNED_SHORT, AttrType::INTEGER, 0, 0, 0, 0}};
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::VU32: {
-      static vtx_config cfgs[] = {{"POSITION", 1, GL_UNSIGNED_INT, AttrType::INTEGER, 0, 0, 0}};
+      static vtx_config cfgs[] = {{"POSITION", 1, GL_UNSIGNED_INT, AttrType::INTEGER, 0, 0, 0, 0}};
+      _setConfig(cfgs);
+      break;
+    }
+    case lev2::EVtxStreamFormat::VU32INST: {
+      static vtx_config cfgs[] = {{"INSTANCE_ID", 1, GL_UNSIGNED_INT, AttrType::INTEGER, 0, 1, 0, 0}};
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12: {
-      static vtx_config cfgs[] = {{"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0}};
+      static vtx_config cfgs[] = {{"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0}};
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12C4: {
       static vtx_config cfgs[] = {
-          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 12, 0, 0},
+          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 12, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12T8: {
-      static vtx_config cfgs[] = {{"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0}, {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 12, 0, 0}};
+      static vtx_config cfgs[] = {{"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0}, {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 12, 0, 0, 0}};
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12N12T16: {
       static vtx_config cfgs[] = {
-          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0},
-          {"TEXCOORD0", 4, GL_FLOAT, AttrType::FLOAT, 24, 0, 0},
+          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0, 0},
+          {"TEXCOORD0", 4, GL_FLOAT, AttrType::FLOAT, 24, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
@@ -653,55 +662,55 @@ static bool EnableVtxBufComponents(const VertexBufferBase& vtxbuf, const svarp_t
     case lev2::EVtxStreamFormat::V12N12B12T16: {
       static vtx_config cfgs[] = {
           {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0},
-          {"BINORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 24, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 36, 0, 0},
-          {"TEXCOORD1", 2, GL_FLOAT, AttrType::FLOAT, 44, 0, 0},
+          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0, 0},
+          {"BINORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 24, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 36, 0, 0, 0},
+          {"TEXCOORD1", 2, GL_FLOAT, AttrType::FLOAT, 44, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12N12T8DF12C4: {
       static vtx_config cfgs[] = {
-          {"POSITION",  3, GL_FLOAT, AttrType::FLOAT,         0, 0, 0},
-          {"NORMAL",    3, GL_FLOAT, AttrType::FLOAT_NORMALIZED,         12, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT,        24, 0, 0},
-          {"TEXCOORD1", 3, GL_FLOAT, AttrType::FLOAT,        32, 0, 0},
-          {"COLOR0",    4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 44, 0, 0},
+          {"POSITION",  3, GL_FLOAT, AttrType::FLOAT,         0, 0, 0, 0},
+          {"NORMAL",    3, GL_FLOAT, AttrType::FLOAT_NORMALIZED,         12, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT,        24, 0, 0, 0},
+          {"TEXCOORD1", 3, GL_FLOAT, AttrType::FLOAT,        32, 0, 0, 0},
+          {"COLOR0",    4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 44, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12N12T8DU12C4: {
       static vtx_config cfgs[] = {
-          {"POSITION",  3, GL_FLOAT, AttrType::FLOAT,         0, 0, 0},
-          {"NORMAL",    3, GL_FLOAT, AttrType::FLOAT_NORMALIZED,         12, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT,        24, 0, 0},
-          {"TEXCOORD1", 3, GL_UNSIGNED_INT, AttrType::INTEGER, 32, 0, 0},
-          {"COLOR0",    4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 44, 0, 0},
+          {"POSITION",  3, GL_FLOAT, AttrType::FLOAT,         0, 0, 0, 0},
+          {"NORMAL",    3, GL_FLOAT, AttrType::FLOAT_NORMALIZED,         12, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT,        24, 0, 0, 0},
+          {"TEXCOORD1", 3, GL_UNSIGNED_INT, AttrType::INTEGER, 32, 0, 0, 0},
+          {"COLOR0",    4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 44, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12N12B12T8I4W4: {
       static vtx_config cfgs[] = {
-          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0},
-          {"BINORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 24, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 36, 0, 0},
-          {"BONEINDICES", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT, 44, 0, 0},
-          {"BONEWEIGHTS", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 48, 0, 0},
+          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0, 0},
+          {"BINORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 24, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 36, 0, 0, 0},
+          {"BONEINDICES", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT, 44, 0, 0, 0},
+          {"BONEWEIGHTS", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 48, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12N12T8I4W4: {
       static vtx_config cfgs[] = {
-          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 24, 0, 0},
-          {"BONEINDICES", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 32, 0, 0},
-          {"BONEWEIGHTS", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 36, 0, 0},
+          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 24, 0, 0, 0},
+          {"BONEINDICES", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 32, 0, 0, 0},
+          {"BONEWEIGHTS", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 36, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
@@ -714,40 +723,40 @@ static bool EnableVtxBufComponents(const VertexBufferBase& vtxbuf, const svarp_t
     }
     case EVtxStreamFormat::V12N12B12T8C4: {
       static vtx_config cfgs[] = {
-          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT, 12, 0, 0},
-          {"BINORMAL", 3, GL_FLOAT, AttrType::FLOAT, 24, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 36, 0, 0},
-          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 44, 0, 0},
+          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT, 12, 0, 0, 0},
+          {"BINORMAL", 3, GL_FLOAT, AttrType::FLOAT, 24, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 36, 0, 0, 0},
+          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 44, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
     }
     case lev2::EVtxStreamFormat::V12N12T16C4: {
       static vtx_config cfgs[] = {
-          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 24, 0, 0},
-          {"TEXCOORD1", 2, GL_FLOAT, AttrType::FLOAT, 32, 0, 0},
-          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 40, 0, 0},
+          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"NORMAL", 3, GL_FLOAT, AttrType::FLOAT_NORMALIZED, 12, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 24, 0, 0, 0},
+          {"TEXCOORD1", 2, GL_FLOAT, AttrType::FLOAT, 32, 0, 0, 0},
+          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 40, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
     }
     case EVtxStreamFormat::V12C4T16: {
       static vtx_config cfgs[] = {
-          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 12, 0, 0},
-          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 16, 0, 0},
-          {"TEXCOORD1", 2, GL_FLOAT, AttrType::FLOAT, 24, 0, 0}};
+          {"POSITION", 3, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"COLOR0", 4, GL_UNSIGNED_BYTE, AttrType::FLOAT_NORMALIZED, 12, 0, 0, 0},
+          {"TEXCOORD0", 2, GL_FLOAT, AttrType::FLOAT, 16, 0, 0, 0},
+          {"TEXCOORD1", 2, GL_FLOAT, AttrType::FLOAT, 24, 0, 0, 0}};
       _setConfig(cfgs);
       break;
     }
     case EVtxStreamFormat::V16T16C16: {
       static vtx_config cfgs[] = {
-          {"POSITION", 4, GL_FLOAT, AttrType::FLOAT, 0, 0, 0},
-          {"TEXCOORD0", 4, GL_FLOAT, AttrType::FLOAT, 16, 0, 0},
-          {"COLOR0", 4, GL_FLOAT, AttrType::FLOAT, 32, 0, 0},
+          {"POSITION", 4, GL_FLOAT, AttrType::FLOAT, 0, 0, 0, 0},
+          {"TEXCOORD0", 4, GL_FLOAT, AttrType::FLOAT, 16, 0, 0, 0},
+          {"COLOR0", 4, GL_FLOAT, AttrType::FLOAT, 32, 0, 0, 0},
       };
       _setConfig(cfgs);
       break;
@@ -1005,19 +1014,19 @@ void GlGeometryBufferInterface::DrawPrimitiveEML(
   if (ivcount) {
     GL_ERRORCHECK();
     switch (eType) {
-      case PrimitiveType::LINES: { 
+      case PrimitiveType::LINES: {
         glDrawArrays(GL_LINES, ivbase, ivcount );
         break;
       }
-      case PrimitiveType::TRIANGLES: { 
+      case PrimitiveType::TRIANGLES: {
         glDrawArrays(GL_TRIANGLES, ivbase, ivcount );
         break;
       }
-      case PrimitiveType::TRIANGLESTRIP: { 
+      case PrimitiveType::TRIANGLESTRIP: {
         glDrawArrays(GL_TRIANGLE_STRIP, ivbase, ivcount );
         break;
       }
-      case PrimitiveType::POINTS: { 
+      case PrimitiveType::POINTS: {
         glEnable(GL_PROGRAM_POINT_SIZE);
         glDrawArrays(GL_POINTS, ivbase, ivcount );
         break;
@@ -1124,8 +1133,6 @@ void GlGeometryBufferInterface::DrawInstancedIndexedPrimitiveEML(
 
   int iNum          = idxbuf.GetNumIndices();
   auto plat_handle = idxbuf._impl.getShared<GlIndexBufferImpl>();
-  int imin          = plat_handle->mMinIndex;
-  int imax          = plat_handle->mMaxIndex;
   GLenum glprimtype = 0;
 
   auto indextype = plat_handle->_indexGlType;
@@ -1133,17 +1140,15 @@ void GlGeometryBufferInterface::DrawInstancedIndexedPrimitiveEML(
   if (iNum) {
     GL_ERRORCHECK();
     switch (eType) {
-      case PrimitiveType::LINES: { // orkprintf( "drawarrays: %d lines\n", iNum );
+      case PrimitiveType::LINES: {
         glprimtype = GL_LINES;
         break;
       }
       case PrimitiveType::TRIANGLES:
-        // printf( "drawindexedtris inum<%d> imin<%d> imax<%d>\n", iNum/3, imin, imax );
         glprimtype = GL_TRIANGLES;
         miTrianglesRendered += (iNum / 3) * instance_count;
         break;
       case PrimitiveType::TRIANGLESTRIP:
-        // printf( "drawindexedtristrip inum<%d>\n", iNum-2 );
         glprimtype = GL_TRIANGLE_STRIP;
         miTrianglesRendered += (iNum - 2) * instance_count;
         break;
@@ -1162,7 +1167,6 @@ void GlGeometryBufferInterface::DrawInstancedIndexedPrimitiveEML(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-
 void* GlGeometryBufferInterface::LockIB(IndexBufferBase& idxbuf, int ibase, int icount) {
   void* rval = nullptr;
   OrkAssert(ibase == 0);
@@ -1181,7 +1185,7 @@ void* GlGeometryBufferInterface::LockIB(IndexBufferBase& idxbuf, int ibase, int 
     plat_handle = idxbuf._impl.getShared<GlIndexBufferImpl>().get();
   }
   rval = plat_handle->_buffer;
-  return rval;    
+  return rval;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ork.lev2/src/gfx/gl/glfx/parser_node_stateblock.cpp
+++ b/ork.lev2/src/gfx/gl/glfx/parser_node_stateblock.cpp
@@ -69,83 +69,88 @@ void StateBlockNode::_generate2(shaderbuilder::BackEnd& backend) const {
 
   if (_culltest != "") {
     if (_culltest == "OFF"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetCullTest(lev2::ECullTest::OFF); });
       });
     }
     else if (_culltest == "PASS_FRONT"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetCullTest(lev2::ECullTest::PASS_FRONT); });
       });
     }
     else if (_culltest == "PASS_BACK"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetCullTest(lev2::ECullTest::PASS_BACK); });
       });
     }
   }
   if (_depthmask != "") {
     bool bena = (_depthmask == "true");
-    psb->addStateFn([=](Context* t) { 
+    psb->addStateFn([=](Context* t) {
        //t->RSI()->SetZWriteMask(bena); });
     });
   }
   if (_depthtest != "") {
     if (_depthtest == "OFF"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetDepthTest(lev2::EDepthTest::OFF); });
       });
     }
     else if (_depthtest == "LESS"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetDepthTest(lev2::EDepthTest::LESS); });
       });
     }
     else if (_depthtest == "LEQUALS"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetDepthTest(lev2::EDepthTest::LEQUALS); });
       });
     }
     else if (_depthtest == "GREATER"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetDepthTest(lev2::EDepthTest::GREATER); });
       });
     }
     else if (_depthtest == "GEQUALS"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetDepthTest(lev2::EDepthTest::GEQUALS); });
       });
     }
     else if (_depthtest == "EQUALS"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetDepthTest(lev2::EDepthTest::EQUALS); });
       });
     }
   }
   if (_blendmode != "") {
     if (_blendmode == "ADDITIVE"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetBlending(lev2::BlendingMacro::ADDITIVE); });
       });
     }
     else if (_blendmode == "ALPHA_ADDITIVE"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetBlending(lev2::BlendingMacro::ALPHA_ADDITIVE); });
       });
     }
     else if (_blendmode == "SUBTRACTIVE"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetBlending(lev2::BlendingMacro::SUBTRACTIVE); });
       });
     }
     else if (_blendmode == "ALPHA_SUBTRACTIVE"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetBlending(lev2::BlendingMacro::ALPHA_SUBTRACTIVE); });
       });
     }
     else if (_blendmode == "ALPHA"){
-      psb->addStateFn([=](Context* t) { 
+      psb->addStateFn([=](Context* t) {
       //t->RSI()->SetBlending(lev2::BlendingMacro::ALPHA); });
+      });
+    }
+    else if (_blendmode == "PREMA"){
+      psb->addStateFn([=](Context* t) {
+      //t->RSI()->SetBlending(lev2::BlendingMacro::PREMA); });
       });
     }
   }

--- a/ork.lev2/src/gfx/vulkan/vulkan_gbi.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_gbi.cpp
@@ -254,7 +254,7 @@ vkvertexinputconfig_ptr_t VkGeometryBufferInterface::vertexInputState(vkvtxbuf_p
   vis.pVertexBindingDescriptions      = &rval->_binding_description;
   vis.vertexAttributeDescriptionCount = rval->_attribute_descriptions.size();
   vis.pVertexAttributeDescriptions    = rval->_attribute_descriptions.data();
-  
+
   // add to cache
   vbuf->_vif_to_layout[vif_hash] = rval;
 
@@ -506,7 +506,7 @@ void VkGeometryBufferInterface::DrawIndexedPrimitiveEML(
 
   auto& vk_buffer = vk_ibimpl->_vkbuffer->_vkbuffer;
 
-  vkCmdBindIndexBuffer( CB->_vkcmdbuf,  // command buffer 
+  vkCmdBindIndexBuffer( CB->_vkcmdbuf,  // command buffer
                         vk_buffer,      // index buffer
                         0,              // start at first index in index buffer
                         vk_index_size); // index type


### PR DESCRIPTION
We introduced:
- `InstancedIndexedPrimitive`, primitive to render N instances of a single indexed mesh
- `VU32INST` + `SVtxVU32Inst`, new vertex format to handle 32bit instance ID, with the instance divisor set to 1.

Python interface:
- `InstancedIndexedQuadPrimitive`, wrapper for indexed quads. Useful for gaussian splats.
- `PointsPrimitiveVU32`, point primitive that uses 32bit IDs. Can be used with geometry shaders to expand each point into a custom sprite.

Other:
- Added `PREMA` blend mode token to the state block parser.