### PR TITLE
reverts quick fixes to profiler ands sets compile time define to full…

### DIFF
--- a/ork.core/inc/ork/kernel/profiler.h
+++ b/ork.core/inc/ork/kernel/profiler.h
@@ -69,6 +69,7 @@
 #include <ork/util/crc.h>
 #include <ork/orkstd.h>
 #include <ork/kernel/concurrent_queue.h>
+#include <ork/util/logger.h>
 #include <deque>
 #include <map>
 #include <memory>
@@ -87,6 +88,8 @@ namespace ork {
 #define CHANNEL_AUDIO  "AudioThread"
 #define CHANNEL_GPU    "GPU"
 
+#ifdef ORK_PROFILER_ENABLE
+
 // Initial frame begin defines what type the channel is and lazy allocates on first call. Additional optional parameters can be passed in.
 #define OrkProfilerFrameBegin(_channel_name, _type, ...) _OrkStaticAcquireChannel(_channel_name, _type, OrkUnique(_series), frameBegin, __VA_ARGS__)
 #define OrkProfilerFrameEnd(_channel_name)               _OrkStaticGetChannel(_channel_name, OrkUnique(_series), frameEnd)
@@ -100,6 +103,17 @@ namespace ork {
 
 // Events are single occurances that are draw as vertical markers rather than a continuous graph.
 #define OrkProfilerEvent(_channel_name, _series_name)  _OrkStaticSeries(_channel_name,  _series_name, EventProfilerSeries, OrkUnique(_series), addEvent)
+
+#else
+
+#define OrkProfilerFrameBegin(_channel_name, _type, ...)
+#define OrkProfilerFrameEnd(_channel_name)
+#define OrkProfilerSampleBegin(_channel_name, _series_name)
+#define OrkProfilerSampleEnd(_channel_name, _series_name)
+#define OrkProfilerSampleScope(_channel_name, _series_name)
+#define OrkProfilerEvent(_channel_name, _series_name)
+
+#endif
 
 // We use macros and stamp down copies of the static var and if statement to evade std::map lookup every time
 // and rely on CPU prediction to optimize away the overhead of the profiler marker after first call.
@@ -116,7 +130,7 @@ namespace ork {
 #define _OrkStaticSeries(_channel_name, _series_name, _type, _var, _call) \
     static _type* _var = nullptr; \
     if (_var == nullptr) [[unlikely]] _var = Profiler::acquireSeries<_type>(_channel_name, CRCU(_channel_name), _series_name, CRCU(_series_name)); \
-    if (_var) [[likely]] _var->_call()
+    _var->_call()
 
 #define _OrkStaticScope(_channel_name, _series_name, _var) \
     static SampleProfilerSeries* _var = nullptr; \
@@ -240,7 +254,7 @@ using profiler_channel_ptr_t = std::shared_ptr<ProfilerChannel>;
 struct ProfilerScope {
   ProfilerScope(ProfilerChannel* channel, SampleProfilerSeries* series) : _channel(channel), _series(series) {}
   ~ProfilerScope() {
-    if (!_series || !_series->_sampling) return;
+    if (!_series->_sampling) return;
     _channel->sampleEnd(_series);
   }
   ProfilerChannel* _channel;
@@ -277,6 +291,8 @@ struct CpuProfilerChannel final : ProfilerChannel {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+extern logchannel_ptr_t logchan_prof;
+
 struct Profiler {
 
   // global state values to control all profiler sampling
@@ -304,7 +320,10 @@ struct Profiler {
   }
 
   static ProfilerChannel* getChannel(const char* name, u64 namecrc) {
-    OrkAssertI(_channels.contains(namecrc), "First acquireChannel get trying to getChannel!");
+    if (!_channels.contains(namecrc)) {
+      logchan_prof->log("First acquireChannel %s before calling getChannel!", name);
+    OrkAssertI(_channels.contains(namecrc), "First acquireChannel before calling getChannel!");
+    }
     std::unique_lock lock(_channel_mtx);
     auto& c = _channels[namecrc];
     return (ProfilerChannel*)c.get();
@@ -312,9 +331,11 @@ struct Profiler {
 
   template <typename T>
   static T* acquireSeries(const char* channel_name, u64 channel_namecrc, const char* series_name, u64 series_namecrc) {
+    if (!_channels.contains(channel_namecrc)) {
+      logchan_prof->log("Call frameBegin for %s before calling sampleBegin or sampleScope for %s!", channel_name, series_name);
+      OrkAssertI(_channels.contains(channel_namecrc), "Call frameBegin before calling sampleBegin or sampleScope!");
+    }
     std::unique_lock lock(_channel_mtx);
-    if (!_channels.contains(channel_namecrc))
-      return nullptr; // channel not yet initialized via frameBegin — caller must tolerate nullptr
     auto& c = _channels[channel_namecrc];
     auto& s = c->_series[series_namecrc];
     if (!s) {

--- a/ork.core/src/kernel/profiler.cpp
+++ b/ork.core/src/kernel/profiler.cpp
@@ -5,7 +5,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace ork {
 
-static auto logchan_prof = logger()->configureChannel("PROF", fvec3(0.1, 0.5, 0.9), true);
+logchannel_ptr_t logchan_prof = logger()->configureChannel("PROF", fvec3(0.1, 0.5, 0.9), true);
 
 // #define PROF_LOG(...) do { printf(__VA_ARGS__); fflush(stdout); } while(0)
 #define PROF_LOG(...) ((void)0)

--- a/ork.lev2/inc/ork/lev2/ui/profilerview.h
+++ b/ork.lev2/inc/ork/lev2/ui/profilerview.h
@@ -45,7 +45,11 @@ struct ProfilerView : public ui::Group {
   ui::HandlerResult DoOnUiEvent(ui::event_constptr_t EV) override;
   void _doOnResized() override;
 
+#if defined(ORK_PROFILER_ENABLE)
   void addChannel(const std::string& name) { _channel_names.push_back(name); }
+#else
+  void addChannel(const std::string&) {}
+#endif
 
   // Channels to display, by profiler channel name
   std::vector<std::string> _channel_names;

--- a/ork.lev2/pyext/src/pyext_ui.cpp
+++ b/ork.lev2/pyext/src/pyext_ui.cpp
@@ -742,12 +742,14 @@ void pyinit_ui(py::module& module_lev2) {
   uimodule.def(
       "profiler_add_event",
       [](const std::string& channel_name, const std::string& series_name) {
+#ifdef ORK_PROFILER_ENABLE
         // This is doing a fully lookup through the shared_mutex every call.
         // If we ever need a way to call this hundrends of times a frame this needs to change.
         auto* es = Profiler::acquireSeries<EventProfilerSeries>(
             channel_name.c_str(), CrcString(channel_name.c_str()).hashed(),
             series_name.c_str(), CrcString(series_name.c_str()).hashed());
         es->addEvent();
+#endif
       },
       py::arg("channel_name"),
       py::arg("series_name"));
@@ -755,10 +757,12 @@ void pyinit_ui(py::module& module_lev2) {
   uimodule.def(
       "profiler_sample_begin",
       [](const std::string& channel_name, const std::string& series_name) {
+#ifdef ORK_PROFILER_ENABLE
         auto* ss = Profiler::acquireSeries<SampleProfilerSeries>(
             channel_name.c_str(), CrcString(channel_name.c_str()).hashed(),
             series_name.c_str(), CrcString(series_name.c_str()).hashed());
         ss->sampleBegin();
+#endif
       },
       py::arg("channel_name"),
       py::arg("series_name"));
@@ -766,10 +770,12 @@ void pyinit_ui(py::module& module_lev2) {
   uimodule.def(
       "profiler_sample_end",
       [](const std::string& channel_name, const std::string& series_name) {
+#ifdef ORK_PROFILER_ENABLE
         auto* ss = Profiler::acquireSeries<SampleProfilerSeries>(
             channel_name.c_str(), CrcString(channel_name.c_str()).hashed(),
             series_name.c_str(), CrcString(series_name.c_str()).hashed());
         ss->sampleEnd();
+#endif
       },
       py::arg("channel_name"),
       py::arg("series_name"));

--- a/ork.lev2/src/ezapp.cpp
+++ b/ork.lev2/src/ezapp.cpp
@@ -1138,12 +1138,14 @@ void OrkEzApp::_mainThreadLoopBegin() {
 
     if (_mainWindow->_onGpuExit) {
       _mainWindow->_onGpuExit(context);
-    }
+  }
   };
   ctx->_runloopBegin();
 }
 ///////////////////////////////////////////////////////////////////////////////
 void OrkEzApp::_mainThreadLoopIter() {
+  OrkProfilerFrameBegin(CHANNEL_MAIN, CpuProfilerChannel, {.capture_fps = true});
+
   if (_mainWindow) {
     auto ctx = _mainWindow->_ctqt;
     ctx->_runloopIter();
@@ -1163,6 +1165,8 @@ void OrkEzApp::_mainThreadLoopIter() {
   // Phase 5: Render secondary windows and cleanup closed ones
   _renderSecondaryWindows();
   _cleanupClosedSecondaryWindows();
+
+  OrkProfilerFrameEnd(CHANNEL_MAIN);
 }
 ///////////////////////////////////////////////////////////////////////////////
 void OrkEzApp::_mainThreadLoopEnd() {

--- a/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
@@ -1964,26 +1964,21 @@ void VkProfilerChannel::frameEnd() {
 
   _cmdbuf = VK_NULL_HANDLE;
 
-  // Readback timestamp queries (skip if none were recorded or readback fails)
-  bool queries_valid = false;
-  if (_query_index > 0) {
+  // Readback timestamp queries
     _timestamps.resize(_query_index);
     VkResult ok = vkGetQueryPoolResults(_device, _query_pool, 0, _query_index, _query_index * sizeof(u64),
       _timestamps.data(), sizeof(u64), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
-    queries_valid = (ok == VK_SUCCESS);
-  }
+  OrkAssert(VK_SUCCESS == ok);
   _query_index = 0;
 
-  if (queries_valid) {
     // Accumulate isolated ticks from per-segment spans
     for (auto& span : _vk_spans)
       span.series->_isolated_ticks += _timestamps[span.end_query] - _timestamps[span.begin_query];
+  _vk_spans.clear();
 
     // Accumulate total ticks from full-duration spans (begin_total_query -> end_query)
     for (auto& span : _vk_total_spans)
       span.series->_total_ticks += _timestamps[span.end_query] - _timestamps[span.begin_total_query];
-  }
-  _vk_spans.clear();
   _vk_total_spans.clear();
 
   // accumulate in series through base call

--- a/ork.lev2/src/gfx/vulkan/vulkan_fbi_rtgroup.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fbi_rtgroup.cpp
@@ -212,6 +212,7 @@ void VkFrameBufferInterface::_pushRtGroup(rtgroup_rawptr_t rtgroup) {
         break;
     } // switch (rtgroup->_usage) {
 
+#ifdef ORK_PROFILER_ENABLE
     // STEP 3: Start per-RTG GPU perf block only when transitioning to a new RTG.
     // Retain profiler_series lookup/creation on rtgroup so it doesn't need to happen every cycle for every RTG.
     if (rtgroup->_profiler_series == nullptr) {
@@ -219,9 +220,10 @@ void VkFrameBufferInterface::_pushRtGroup(rtgroup_rawptr_t rtgroup) {
       rtgroup->_profiler_series = Profiler::acquireSeries<SampleProfilerSeries>(CHANNEL_GPU, name);
     }
     // _profiler_owner tracks which stack entry owns the sample lifetime so that nested push/pop and resume cycles don't create orphaned begin/end pairs.
-    stack_impl->_profiler_owner = (_active_rtgroup != rtgroup) && (rtgroup->_profiler_series != nullptr);
+    stack_impl->_profiler_owner = (_active_rtgroup != rtgroup);
     if (stack_impl->_profiler_owner)
       rtgroup->_profiler_series->sampleBegin();
+#endif
 
     // STEP 4: Now begin the new render pass
     RTGIMPL->_transitionToRenderTarget(_contextVK->primary_cb());
@@ -257,9 +259,11 @@ void VkFrameBufferInterface::_popRtGroup() {
   auto stack_impl   = popped_item._impl.getShared<VkRtgStackItemImpl>();
   auto finished_rtg = popped_item._rtgroup;
 
+#ifdef ORK_PROFILER_ENABLE
   // End per-RTG GPU perf block only for the entry that owns the sample lifetime.
   if (stack_impl->_profiler_owner)
     finished_rtg->_profiler_series->sampleEnd();
+#endif
 
   if (0)
     logchan_rtgroup->log(

--- a/ork.lev2/src/ui/widgets/group.cpp
+++ b/ork.lev2/src/ui/widgets/group.cpp
@@ -6,6 +6,7 @@
 #include <ork/profiling.inl>
 #include <ork/lev2/gfx/gfxmaterial_ui.h>
 #include <ork/lev2/gfx/pri.h>
+#include <ork/kernel/profiler.h>
 
 namespace ork { namespace ui {
 /////////////////////////////////////////////////////////////////////////
@@ -966,11 +967,15 @@ Widget* LayoutGroup::doRouteUiEvent(event_constptr_t ev) {
   if (ev->_eventcode == ui::EventCode::KEY_DOWN) {
     if (ev->miKeyCode == '~' || ev->miKeyCode == '`') {
       if (ev->mbSHIFT) {
+#if defined(ORK_PROFILER_ENABLE)
         if (_profiler_overlay_widget) {
           _profiler_overlay_enabled = !_profiler_overlay_enabled;
           SetDirty();
           return this;
         }
+#else
+        logchan_prof->log("Profiler overlay unavailable: build was not compiled with ORK_PROFILER_ENABLE. Run `ork.build.py --profiler`.");
+#endif
       } else {
         if (_overlay_widget) {
           _overlay_enabled = !_overlay_enabled;

--- a/orkid.cmake
+++ b/orkid.cmake
@@ -299,7 +299,7 @@ function(ork_std_target_set_defs the_target)
 
 
   IF(PROFILER)
-    list(APPEND def_list -DBUILD_WITH_EASY_PROFILER)
+    list(APPEND def_list -DORK_PROFILER_ENABLE)
   ENDIF()
 
 #  message(STATUS "ARCHITECTURE: ${ARCHITECTURE}")


### PR DESCRIPTION
This reverts some of the quick fixes to profiler and instead implements a define to have it be fully compiled out.

Also adds a few more logs to give better notice of frame and sample calls not being in proper order.