### PR TITLE
Swapchain TimePredictor

### DIFF
--- a/ork.core/inc/ork/kernel/timer.h
+++ b/ork.core/inc/ork/kernel/timer.h
@@ -110,5 +110,38 @@ struct AdaptiveWait {
 using adaptive_wait_ptr_t = std::shared_ptr<AdaptiveWait>;
 
 ///////////////////////////////////////////////////////////////////////////////
+// TimePredictor
+//
+// Tracks a recurring event and predicts when it will next occur.
+// Call markPredictionTarget() each time the event happens.
+// Call predictNextTarget() at any time to get the predicted absolute tick
+// of the next occurrence, based on a rolling average of observed intervals.
+///////////////////////////////////////////////////////////////////////////////
+
+struct TimePredictor {
+
+  static constexpr size_t HISTORY_SIZE = 16;
+
+  // Record that the tracked event just occurred.
+  // Updates the rolling average interval between occurrences.
+  void markPredictionTarget();
+
+  // Predicted absolute system tick of the next occurrence.
+  // Returns last_mark + avg_interval, or 0 until 2 marks have been recorded.
+  u64 predictNextTarget() const;
+
+  u64 avgIntervalNs() const { return _avg_interval_ns; }
+
+  u64    _last_mark_tick  = 0;
+  u64    _last_prediction = 0;
+  u64    _avg_interval_ns = 0;
+  u64    _history[HISTORY_SIZE] = {};
+  size_t _history_index   = 0;
+  size_t _history_count   = 0;
+};
+
+using time_predictor_ptr_t = std::shared_ptr<TimePredictor>;
+
+///////////////////////////////////////////////////////////////////////////////
 } // namespace ork
 ///////////////////////////////////////////////////////////////////////////////

--- a/ork.core/src/kernel/timer.cpp
+++ b/ork.core/src/kernel/timer.cpp
@@ -11,6 +11,7 @@
 #include <ork/kernel/kernel.h>
 #include <ork/kernel/timer.h>
 #include <ork/kernel/mutex.h>
+#include <ork/util/logger.h>
 
 #if defined(ORK_OSX) || defined(ORK_IOS)
 #include <mach/mach_time.h>
@@ -32,6 +33,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace ork {
+///////////////////////////////////////////////////////////////////////////////
+
+static logchannel_ptr_t logchan_timer = logger()->configureChannel("TIMER", fvec3(0.7, 0.9, 0.7), true);
+
 ///////////////////////////////////////////////////////////////////////////////
 
 Timer::Timer()
@@ -268,6 +273,38 @@ void usleep(int microsec) {
 ///////////////////////////////////////////////////////////////////////////////
 #endif
 ///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TimePredictor::markPredictionTarget() {
+  u64 now = Timer::getSystemTick();
+  if (_last_mark_tick > 0) {
+    // Log prediction error from previous mark's prediction
+    if (0) {
+      int64_t error_ns = (int64_t)now - (int64_t)_last_prediction;
+      logchan_timer->log("predict error: %+.3f us  avg_interval: %.3f ms",
+                         double(error_ns) * 1e-3,
+                         double(_avg_interval_ns) * 1e-6);
+    }
+    u64 interval = now - _last_mark_tick;
+    _history[_history_index] = interval;
+    _history_index = (_history_index + 1) % HISTORY_SIZE;
+    if (_history_count < HISTORY_SIZE)
+      _history_count++;
+    u64 sum = 0;
+    for (size_t i = 0; i < _history_count; i++)
+      sum += _history[i];
+    _avg_interval_ns = sum / _history_count;
+  }
+  _last_mark_tick   = now;
+  _last_prediction  = predictNextTarget();
+}
+
+u64 TimePredictor::predictNextTarget() const {
+  if (_history_count == 0)
+    return 0;
+  return _last_mark_tick + _avg_interval_ns;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 } // namespace ork

--- a/ork.lev2/inc/ork/lev2/gfx/gfxenv.h
+++ b/ork.lev2/inc/ork/lev2/gfx/gfxenv.h
@@ -473,6 +473,8 @@ public:
   
   Timer _ctxtimer;
 
+  time_predictor_ptr_t _render_timing_estimator = std::make_shared<TimePredictor>();
+
   svar64_t _pyimpl_beforeEndFrame;
 protected:
   RenderingConventions _renderingConventions;

--- a/ork.lev2/inc/ork/lev2/vr/vr.h
+++ b/ork.lev2/inc/ork/lev2/vr/vr.h
@@ -111,6 +111,14 @@ struct Device {
   virtual void gpuUpdate(RenderContextFrameData& RCFD)              = 0;
   virtual void __composite(Context* targ, Texture* twoeyetex) const = 0;
 
+  // Returns the predicted absolute system tick (Timer::getSystemTick() scale)
+  // when the current frame will finish rendering. Used for pose prediction.
+  // Returns 0 if not enough frames have been rendered yet.
+  u64 predictedRenderFinishTick() const;
+
+  // Shared with the gfx context producing frames for this device.
+  ork::time_predictor_ptr_t _render_timing_estimator;
+
   std::map<std::string, fmtx4> _posemap;
   cameramatrices_ptr_t _leftcamera       = nullptr;
   cameramatrices_ptr_t _centercamera     = nullptr;

--- a/ork.lev2/inc/ork/lev2/vr/vr.h
+++ b/ork.lev2/inc/ork/lev2/vr/vr.h
@@ -14,6 +14,7 @@
 #include <ork/math/cmatrix4.h>
 #include <ork/kernel/thread.h>
 #include <ork/kernel/mutex.h>
+#include <ork/kernel/timer.h>
 
 #if defined(ENABLE_LIBSURVIVE)
 #include <libsurvive/survive_api.h>

--- a/ork.lev2/src/ezapp.cpp
+++ b/ork.lev2/src/ezapp.cpp
@@ -1077,6 +1077,13 @@ void OrkEzApp::_mainThreadLoopBegin() {
 
   ctx->_onGpuInit = [this](lev2::Context* context) {
     //logchan_ezapp->log("BEGIN OrkEzApp::_onGpuInit");
+
+    auto vrdev = ork::lev2::orkidvr::device();
+    if (vrdev) {
+      vrdev->_render_timing_estimator = context->_render_timing_estimator;
+      logchan_ezapp->log("Setting gfx context<%p> to vrdevice<%p>.", (void*)context, (void*)vrdev.get());
+    }
+
     context->beginPrimaryCommandBuffer();
     //logchan_ezapp->log("_initdata->_enable_audio<%d>", (int)_initdata->_enable_audio);
 
@@ -1229,6 +1236,7 @@ int OrkEzApp::mainThreadLoop() {
           _cleanupClosedSecondaryWindows();
         }
 
+        // TODO change is so OrkProfilerFrameBegin can forward it's 'capture_fps' value logchannel
         // Track freerun FPS
         if (_initdata->_log_freerun_fps) {
           frame_count += 1.0;

--- a/ork.lev2/src/gfx/vulkan/headers/vk_protos.h
+++ b/ork.lev2/src/gfx/vulkan/headers/vk_protos.h
@@ -1,9 +1,21 @@
-#pragma once 
+#pragma once
+#include <vulkan/vk_enum_string_helper.h>
 namespace ork::dds {
 struct DDS_HEADER;
 }
 ///////////////////////////////////////////////////////////////////////////////
 namespace ork::lev2::vulkan {
+///////////////////////////////////////////////////////////////////////////////
+// OrkVkAssert: assert that a VkResult is VK_SUCCESS, logging the error string if not.
+#define OrkVkAssert(result)                                                \
+  {                                                                        \
+    VkResult _vk_res = (result);                                           \
+    if (_vk_res != VK_SUCCESS) [[unlikely]] {                              \
+      fprintf(stderr, "VkResult error %d (%s) at %s:%d\n",                 \
+              (int)_vk_res, string_VkResult(_vk_res), __FILE__, __LINE__); \
+      OrkAssert(false);                                                    \
+    }                                                                      \
+  }
 ///////////////////////////////////////////////////////////////////////////////
 inline VkDeviceSize vkAlignUp(
     VkDeviceSize value,       //

--- a/ork.lev2/src/gfx/vulkan/headers/vk_rtgroup.h
+++ b/ork.lev2/src/gfx/vulkan/headers/vk_rtgroup.h
@@ -119,7 +119,8 @@ struct VkSwapChain {
   VkResult acquireImage(vkcontext_rawptr_t ctxVK);
   void enqueueFrame(vkcontext_rawptr_t ctxVK);
   void enqueuePresentFrame(vkcontext_rawptr_t ctxVK);
-  void waitPresentFrame(vkcontext_rawptr_t ctxVK);
+  void waitFrame();
+  void incrementFrame();
   size_t subIndex() const; // Which frame-in-flight we're on (0 or 1 if MAX=2)
 
   void _submitFrameWithSemaphores(vkcontext_rawptr_t ctxVK);
@@ -142,7 +143,7 @@ std::vector<vkimageobj_ptr_t> _swapChainImages;
   std::vector<uint64_t> _allWaitValues;
   std::vector<VkPipelineStageFlags> _allWaitStages;
 
-  size_t _currentFrame = 0; // Which frame-in-flight we're on (0 or 1 if MAX=2)
+  u64 _currentFrame = 0; // Increments each frame TODO this should be in vkcontext
   int _width = 0;
   int _height = 0;
   uint32_t _curSwapWriteImage = 0xffffffff;

--- a/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
@@ -9,7 +9,6 @@
 #include "vulkan_captureasync.h"
 #include "vulkan_ubo_dynamic.h"
 #include <ork/lev2/gfx/image.h>
-#include <vulkan/vk_enum_string_helper.h>
 
 #define USE_OIIO
 #if defined(USE_OIIO)
@@ -335,8 +334,7 @@ void VkContext::_initVulkanCommon() {
   CPCI_GFX.flags            = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT //
                    | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
 
-  VkResult OK = vkCreateCommandPool(_vkdevice, &CPCI_GFX, nullptr, &_vkcmdpool_graphics);
-  OrkAssert(OK == VK_SUCCESS);
+  OrkVkAssert(vkCreateCommandPool(_vkdevice, &CPCI_GFX, nullptr, &_vkcmdpool_graphics));
 
   ////////////////////////////
   // create primary command buffer impls
@@ -400,8 +398,7 @@ void VkContext::_initVulkanCommon() {
   poolInfo.pPoolSizes    = poolSizes.data();
   poolInfo.maxSets       = DESCRIPTORSET_COUNT; // Maximum number of descriptor sets to allocate from this pool
 
-  OK = vkCreateDescriptorPool(_vkdevice, &poolInfo, nullptr, &_vkDescriptorPool);
-  OrkAssert(OK == VK_SUCCESS);
+  OrkVkAssert(vkCreateDescriptorPool(_vkdevice, &poolInfo, nullptr, &_vkDescriptorPool));
   
   ////////////////////////////
   // create default texture implementations
@@ -514,8 +511,7 @@ void VkContext::_initDefaultTextures() {
         OrkAssert(false);
     }
     
-    VkResult ok = vkCreateImageView(_vkdevice, &viewInfo, nullptr, &tex_obj->_imgobj[0]->_vkimageview);
-    OrkAssert(VK_SUCCESS == ok);
+    OrkVkAssert(vkCreateImageView(_vkdevice, &viewInfo, nullptr, &tex_obj->_imgobj[0]->_vkimageview));
 
     // Initialize with black data (we'll need to transition and fill the texture)
     // For now, just transition to shader read optimal
@@ -777,6 +773,7 @@ void VkContext::_doEndPrimaryCommandBuffer() {
 ///////////////////////////////////////////////////////////////////////////////
 
 void VkContext::_doSubmitPrimaryCommandBuffer(){
+  OrkProfilerSampleScope(CHANNEL_MAIN, "vk:doSubmitPrimaryCommandBuffer");
 
   auto swapchain = _fbi->_swapchain;
 #if defined(__linux__)
@@ -786,6 +783,11 @@ void VkContext::_doSubmitPrimaryCommandBuffer(){
 #endif
 
   if (swapchain) {
+
+    ////////////////////////////////////////
+    // Swapchain
+    ////////////////////////////////////////
+
     // Onscreen rendering with GLFW swapchain
     bool semas_empty = false;
     _pendingOneShotSemas.atomicOp([&](vkcompsema_set_t& unlocked) {
@@ -805,27 +807,33 @@ void VkContext::_doSubmitPrimaryCommandBuffer(){
 
     // Submit
     if ( not semas_empty) {
-      OrkProfilerSampleScope(CHANNEL_MAIN, "vk:submit_semaphores");
       // Submit with timeline semaphores
       swapchain->_submitFrameWithSemaphores(this);
     } else {
-      OrkProfilerSampleScope(CHANNEL_MAIN, "vk:enqueue_frame");
       // Normal submission
       swapchain->enqueueFrame(this);
     }
 
-    ///////////////////////////////////////////////////////
     // Present !
-    ///////////////////////////////////////////////////////
-    {
-      OrkProfilerSampleScope(CHANNEL_MAIN, "vk:present");
-      swapchain->enqueuePresentFrame(this);
-      swapchain->waitPresentFrame(this);
-    }
+    swapchain->enqueuePresentFrame(this);
 
-    // Process pending captures after swapchain frame completion
+    // Wait for only the frame which was just submitted to finish. (Not the present)
+    swapchain->waitFrame();
+
+    _render_timing_estimator->markPredictionTarget();
+
+    // Process pending captures. Assumes the frame has been waited.
     _processPendingCaptures();
+
+    // Incremenet frame after wait. Meaning there is no pipelining of frames.
+    swapchain->incrementFrame();
+
   } else if (swapchain_drm) {
+
+    ////////////////////////////////////////
+    // DRM
+    ////////////////////////////////////////
+
 #if defined(__linux__)
     // Onscreen rendering with DRM swapchain
     bool semas_empty = false;
@@ -862,6 +870,11 @@ void VkContext::_doSubmitPrimaryCommandBuffer(){
     _processPendingCaptures();
 #endif
   } else {
+
+    ////////////////////////////////////////
+    // Offscreen
+    ////////////////////////////////////////
+
     // Offscreen rendering - handle completion semaphores
     bool semas_empty = false;
     _pendingOneShotSemas.atomicOp([&](vkcompsema_set_t& unlocked) {
@@ -1015,8 +1028,8 @@ void VkContext::_doPreBeginFrame() {
   // begin gpu profiler frame after we have setup commandbuffer
   // must use beginProfilerFrame overload to set cmdbuf for frame
   VkProfilerChannel::BeginParams profiler_params = {
-    .device           = _vkdevice, 
-    .timestamp_period = _vkdeviceinfo->_devprops.limits.timestampPeriod, 
+    .device           = _vkdevice,
+    .timestamp_period = _vkdeviceinfo->_devprops.limits.timestampPeriod,
     .cmdbuf           = primary_cb()->_vkcmdbuf,
   };
   OrkProfilerFrameBegin(CHANNEL_GPU, VkProfilerChannel, profiler_params);
@@ -1114,6 +1127,7 @@ void VkContext::_onGpuPostInit() {
 ///////////////////////////////////////////////////////////////////////////////
 
 void VkContext::_doEndFrame() {
+  OrkProfilerSampleScope(CHANNEL_MAIN, "vk:doEndFrame");
   
   auto main_rtg = _fbi->_ensureMainRtg();
   ////////////////////////
@@ -1289,13 +1303,12 @@ void VkContext::initializeWindowContext(
         vkGetInstanceProcAddr(_GVI->_instance, "vkCreateHeadlessSurfaceEXT");
 
       if (vkCreateHeadlessSurfaceEXT) {
-        VkResult OK = vkCreateHeadlessSurfaceEXT(
+        OrkVkAssert(vkCreateHeadlessSurfaceEXT(
           _GVI->_instance,
           &headlessInfo,
           nullptr,
           &_vkpresentationsurface
-        );
-        OrkAssert(OK == VK_SUCCESS);
+        ));
         logchan_vkctx->log("Headless surface created successfully");
       } else {
         logchan_vkctx->log("ERROR: vkCreateHeadlessSurfaceEXT not available");
@@ -1303,8 +1316,7 @@ void VkContext::initializeWindowContext(
       }
     } else {
       // Original onscreen path
-      VkResult OK = glfwCreateWindowSurface(_GVI->_instance, glfw_window, nullptr, &_vkpresentationsurface);
-      OrkAssert(OK == VK_SUCCESS);
+      OrkVkAssert(glfwCreateWindowSurface(_GVI->_instance, glfw_window, nullptr, &_vkpresentationsurface));
     }
   }
 
@@ -1491,13 +1503,12 @@ void VkContext::initializeLoaderContext() {
       vkGetInstanceProcAddr(_GVI->_instance, "vkCreateHeadlessSurfaceEXT");
 
     if (vkCreateHeadlessSurfaceEXT) {
-      VkResult OK = vkCreateHeadlessSurfaceEXT(
+      OrkVkAssert(vkCreateHeadlessSurfaceEXT(
         _GVI->_instance,
         &headlessInfo,
         nullptr,
         &temp_surface
-      );
-      OrkAssert(OK == VK_SUCCESS);
+      ));
     }
   }
 
@@ -1928,8 +1939,7 @@ void VkProfilerChannel::frameBegin(BeginParams params) {
       .queryType = VK_QUERY_TYPE_TIMESTAMP,
       .queryCount = MAX_GPU_PERF_QUERIES * 2, // 2 timestamps per block (begin + end)
     };
-    VkResult ok = vkCreateQueryPool(_device, &info, nullptr, &_query_pool);
-    OrkAssert(ok == VK_SUCCESS);  
+    OrkVkAssert(vkCreateQueryPool(_device, &info, nullptr, &_query_pool));
   }
 
   if (!_vk_span_stack.empty()) [[unlikely]] {
@@ -1966,19 +1976,18 @@ void VkProfilerChannel::frameEnd() {
 
   // Readback timestamp queries
   _timestamps.resize(_query_index);
-  VkResult ok = vkGetQueryPoolResults(_device, _query_pool, 0, _query_index, _query_index * sizeof(u64),
-    _timestamps.data(), sizeof(u64), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
-  OrkAssert(VK_SUCCESS == ok);
+  OrkVkAssert(vkGetQueryPoolResults(_device, _query_pool, 0, _query_index, _query_index * sizeof(u64),
+    _timestamps.data(), sizeof(u64), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT));
   _query_index = 0;
 
-  // Accumulate isolated ticks from per-segment spans
+    // Accumulate isolated ticks from per-segment spans
   for (auto& span : _vk_spans)
-    span.series->_isolated_ticks += _timestamps[span.end_query] - _timestamps[span.begin_query];
+      span.series->_isolated_ticks += _timestamps[span.end_query] - _timestamps[span.begin_query];
   _vk_spans.clear();
 
-  // Accumulate total ticks from full-duration spans (begin_total_query -> end_query)
+    // Accumulate total ticks from full-duration spans (begin_total_query -> end_query)
   for (auto& span : _vk_total_spans)
-    span.series->_total_ticks += _timestamps[span.end_query] - _timestamps[span.begin_total_query];
+      span.series->_total_ticks += _timestamps[span.end_query] - _timestamps[span.begin_total_query];
   _vk_total_spans.clear();
 
   // accumulate in series through base call

--- a/ork.lev2/src/gfx/vulkan/vulkan_fbi.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fbi.cpp
@@ -69,6 +69,8 @@ void VkFrameBufferInterface::_setScissor(int iX, int iY, int iW, int iH) {
 void VkFrameBufferInterface::_doBeginFrame() {
   static int frame_log_count = 0;
 
+  // TODO Framebuffer should not render directly to the swap.
+  // Render to something else then blit to swap.
   if (_swapchain) {
     _swapchain->_update();
   }

--- a/ork.lev2/src/gfx/vulkan/vulkan_fbi_capture.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fbi_capture.cpp
@@ -128,6 +128,7 @@ VkFrameBufferInterface::captureToTexture(const RtBuffer* inpbuf, Texture& tex, v
 ///////////////////////////////////////////////////////////////////////////////
 
 void VkContext::_processPendingCaptures() {
+  OrkProfilerSampleScope(CHANNEL_MAIN, "vk:processPendingCaptures");
 
   if (_pending_captures.empty()) {
     return;
@@ -139,6 +140,12 @@ void VkContext::_processPendingCaptures() {
 
   for (auto capture_async : captures_to_process) {
     auto async_impl = capture_async->_impl.getShared<VkCaptureAsyncImpl>();
+
+    // Currently it is assume prior frame was waited so we do not run this nor use the fence on the async_impl.
+    // TODO when we start to buffer frames we will need a captures_to_process buffer for each frame. 
+    // Wait for the GPU to finish writing to the staging buffer before reading it back
+    // if (async_impl->_fence)
+    //   async_impl->_fence->wait();
 
     // Get the capture buffer implementation
     auto capbuf_impl    = async_impl->capture_buffer->_impl.getShared<VkCaptureBufferImpl>();

--- a/ork.lev2/src/gfx/vulkan/vulkan_swapchain.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_swapchain.cpp
@@ -50,7 +50,6 @@ void VkSwapChain::_buildup() {
       _imageAcquiredSemaphores.push_back(bin_sema_imgacq);
       _renderCompleteSemaphores.push_back(bin_sema_rencom);
       _frameFences.push_back(fence);
-      fence->reset();
     }
   } else {
     logchan_swapchain->log("_buildup: Reusing existing synchronization objects");
@@ -448,60 +447,43 @@ VkResult VkSwapChain::acquireImage(vkcontext_rawptr_t ctxVK) {
   // Get SwapChain Image
   ///////////////////////////////////////////////////
 
-  bool ok_to_transition = false;
+  // DEBUG: Log semaphore state before acquire
+  auto semaphore = _imageAcquiredSemaphores[sub_index]->_vksema;
+  if(0)logchan_swapchain->log("acquireImage: attempting vkAcquireNextImageKHR with semaphore %p (sub_index %zu)", 
+                        (void*)semaphore, sub_index);
+  
+  VkResult status    = vkAcquireNextImageKHR(
+      ctxVK->_vkdevice,
+      _vkSwapChain,
+      std::numeric_limits<uint64_t>::max(),
+      semaphore, // Use current frame's semaphore
+      VK_NULL_HANDLE,
+      &_curSwapWriteImage);
 
-  while (not ok_to_transition) {
+  // DEBUG: Log acquire result
+  if(0)logchan_swapchain->log("acquireImage: vkAcquireNextImageKHR returned %d, image index %u", 
+                        status, _curSwapWriteImage);
 
-    // Ensure we're using the correct frame's semaphore
-    // and that any previous signal has been consumed
-    if (_curSwapWriteImage != 0xffffffff) {
-      // Previous acquire might have failed mid-operation
-      // Wait for device idle to ensure clean state
-      if(0)logchan_swapchain->log("acquireImage: previous acquire failed, waiting for device idle");
+  switch (status) {
+    case VK_SUCCESS:
+      if(0)logchan_swapchain->log("acquireImage: SUCCESS - acquired image %u", _curSwapWriteImage);
+      break;
+    case VK_SUBOPTIMAL_KHR:
+    case VK_ERROR_OUT_OF_DATE_KHR: {
+      logchan_swapchain->log("acquireImage: SWAPCHAIN OUT OF DATE - status %d", status);
       vkDeviceWaitIdle(ctxVK->_vkdevice);
+      return status;
+      break;
     }
-
-    _curSwapWriteImage = 0xffffffff;
-    
-    // DEBUG: Log semaphore state before acquire
-    auto semaphore = _imageAcquiredSemaphores[sub_index]->_vksema;
-    if(0)logchan_swapchain->log("acquireImage: attempting vkAcquireNextImageKHR with semaphore %p (sub_index %zu)", 
-                          (void*)semaphore, sub_index);
-    
-    VkResult status    = vkAcquireNextImageKHR(
-        ctxVK->_vkdevice,
-        _vkSwapChain,
-        std::numeric_limits<uint64_t>::max(),
-        semaphore, // Use current frame's semaphore
-        VK_NULL_HANDLE,
-        &_curSwapWriteImage);
-
-    // DEBUG: Log acquire result
-    if(0)logchan_swapchain->log("acquireImage: vkAcquireNextImageKHR returned %d, image index %u", 
-                          status, _curSwapWriteImage);
-
-    switch (status) {
-      case VK_SUCCESS:
-        ok_to_transition = true;
-        if(0)logchan_swapchain->log("acquireImage: SUCCESS - acquired image %u", _curSwapWriteImage);
-        break;
-      case VK_SUBOPTIMAL_KHR:
-      case VK_ERROR_OUT_OF_DATE_KHR: {
-        logchan_swapchain->log("acquireImage: SWAPCHAIN OUT OF DATE - status %d", status);
-        vkDeviceWaitIdle(ctxVK->_vkdevice);
-        return status;
-        break;
-      }
-      case VK_ERROR_DEVICE_LOST:{
-        logchan_swapchain->error("acquireImage: VK_ERROR_DEVICE_LOST");
-        OrkAssert(false);
-        break;
-      }
-      default:
-        logchan_swapchain->error("acquireImage: UNEXPECTED STATUS %d", status);
-        OrkAssert(false);
-        break;
+    case VK_ERROR_DEVICE_LOST:{
+      logchan_swapchain->error("acquireImage: VK_ERROR_DEVICE_LOST");
+      OrkAssert(false);
+      break;
     }
+    default:
+      logchan_swapchain->error("acquireImage: UNEXPECTED STATUS %d", status);
+      OrkAssert(false);
+      break;
   }
   OrkAssert(_curSwapWriteImage >= 0);
 
@@ -545,14 +527,12 @@ void VkSwapChain::enqueueFrame(vkcontext_rawptr_t ctxVK) {
 
   // Submit with this frame's fence
   if (sub_index < _frameFences.size()) {
+    OrkProfilerSampleScope(CHANNEL_MAIN, "vk:enqueue_frame_fence_submit");
     auto& fence = _frameFences[sub_index];
     fence->reset();
-    {
-      OrkProfilerSampleScope(CHANNEL_MAIN, "vk:enqueue_frame_fence_submit");
     if(0)logchan_swapchain->log("enqueueFrame: submitting with fence %p (sub_index %zu)", (void*)fence->_vkfence, sub_index);
     vkQueueSubmit(ctxVK->_vkqueue_graphics, 1, &SI, fence->_vkfence);
     if(0)logchan_swapchain->log("enqueueFrame: queue submit complete with fence %p", (void*)fence->_vkfence);
-    }
   } else {
     OrkProfilerSampleScope(CHANNEL_MAIN, "vk:enqueue_frame_submit");
     logchan_swapchain->log("enqueueFrame: WARNING - submitting without fence (sub_index %zu >= fence count %zu)", sub_index, _frameFences.size());
@@ -716,58 +696,19 @@ void VkSwapChain::enqueuePresentFrame(vkcontext_rawptr_t ctxVK) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void VkSwapChain::waitPresentFrame(vkcontext_rawptr_t ctxVK) {
+void VkSwapChain::waitFrame() {
   size_t sub_index = subIndex();
-  
-  // DEBUG: Log frame waiting
   if(0)logchan_swapchain->log("waitPresentFrame: frame %zu, sub_index %zu", _currentFrame, sub_index);
-  
-  // Wait for the current frame's fence to ensure rendering is complete
   auto& fence = _frameFences[sub_index];
-
-  if (fence) {
-    // Check if fence has been submitted (signaled or in-flight)
-    VkResult fence_status = vkGetFenceStatus(ctxVK->_vkdevice, fence->_vkfence);
-
-    if (fence_status == VK_SUCCESS) {
-      // Fence is already signaled - previous frame work is complete
-      // Just reset it, no need to wait (wait would return immediately anyway)
-      if(0)logchan_swapchain->log("waitPresentFrame: fence %p already signaled, resetting", (void*)fence->_vkfence);
-      fence->reset();
-    } else if (fence_status == VK_NOT_READY) {
-      // Fence is not yet signaled - could be in-flight OR never submitted (after reinit)
-      // Only skip wait if we're in the first MAX_FRAMES_IN_FLIGHT frames after reinit
-      // where fences haven't been cycled through yet
-      bool early_after_reinit = (_currentFrame < MAX_FRAMES_IN_FLIGHT);
-
-      if (early_after_reinit) {
-        // Fence was likely never submitted yet, safe to skip wait
-        if(0)logchan_swapchain->log("waitPresentFrame: fence %p not ready (early frame %zu), skipping wait",
-                              (void*)fence->_vkfence, _currentFrame);
-      } else {
-        // Fence should have been submitted MAX_FRAMES_IN_FLIGHT frames ago
-        // It's in-flight, wait for it
-        if(0)logchan_swapchain->log("waitPresentFrame: fence %p in-flight, waiting", (void*)fence->_vkfence);
-        fence->wait();
-        fence->reset();
-      }
-    } else {
-      // VK_ERROR_DEVICE_LOST (-4) or other error
-      logchan_swapchain->log("waitPresentFrame: ERROR - fence %p in error state: %d (device lost?)",
-                            (void*)fence->_vkfence, fence_status);
-      // Device is lost, cannot recover - this is fatal
-      // Log it but don't try to reset (would fail anyway)
-    }
-  } else {
-    logchan_swapchain->log("waitPresentFrame: WARNING - no fence for sub_index %zu", sub_index);
-  }
-  
-  // DEBUG: Log frame completion and increment
-  if(0)logchan_swapchain->log("waitPresentFrame: frame %zu complete, incrementing to frame %zu", 
-                         _currentFrame, _currentFrame + 1);
+  fence->wait();
   _currentFrame++;
-  
-  if(0)logchan_swapchain->log("waitPresentFrame: COMPLETE - frame counter now %zu", _currentFrame);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void VkSwapChain::incrementFrame() {
+  _currentFrame++;
+  if(0)logchan_swapchain->log("frame counter now %zu", _currentFrame);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ork.lev2/src/vr/base.cpp
+++ b/ork.lev2/src/vr/base.cpp
@@ -60,6 +60,13 @@ Device::~Device() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+u64 Device::predictedRenderFinishTick() const {
+  OrkAssertI(_render_timing_estimator, "VR device has no render timing estimator — was a gfx context wired up via ezapp onGpuInit?");
+  return _render_timing_estimator->predictNextTarget();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void Device::overrideSize(int w, int h){
   _width          = w;
   _height         = h;


### PR DESCRIPTION
* Add TimePredictor which tries to predict swapchain present time of a gfx context.
* Wires a gfxContexts TimePredictor to Device through ezapp on init. Lets you call predictedRenderFinishTick from the device to get a prediction on the next swap present.

Added some comments, TODOs and cleanup related to the swapchain render loop that I found when sorting through this.
* Created OrkVkAssert which will log out the name of the VkResult for easier debugging. Updated the OrkAssert(ok == SUCCESS) calls in vkctx to use this.  
* Added a few more OrkProfilerSampleScope calls. Moved existing ones to better location.

Due to how the waitFrame was setup, and also another bug which called vkDeviceWaitIdle every frame, there was no frame pipelining. After each submit it would fully wait for that frame to finish. I did not change that behavior in this PR. It still fully waits for the frame to finish without pipelining. But I made a few changes to make this behavior more apparent and easier to change. Specifically added an incrementFrame separate from the waitFrame, enuqueFrame and presentFrame calls so you can easily discern in which order it is queuing, presenting and waiting.

I found a chunk of the swapchain fence wait logic to not be necessary so I deleted it.