### PR TITLE
Add to session notes.

### DIFF
--- a/ork.data/misc/session_notes.md
+++ b/ork.data/misc/session_notes.md
@@ -23,26 +23,28 @@ This is THE fundamental pattern across the entire Orkid codebase. When forming h
 
 ```cpp
 // CORRECT - Static factory pattern
-class Parent;
-class Child;
+struct Parent;
+struct Child;
 
 using parent_ptr_t = std::shared_ptr<Parent>;
 using child_ptr_t = std::shared_ptr<Child>;
 
-class Parent {
-public:
+struct Parent {
     // Static factory receives parent as shared_ptr
     static child_ptr_t createChild(parent_ptr_t self, /* other args */) {
         auto child = std::make_shared<Child>();
-        child->_parent = self;  // Child stores weak_ptr
+        child->_parent = self;  // Child stores weak_ptr or raw ptr (see note below)
         return child;
     }
 };
 
-class Child {
-    std::weak_ptr<Parent> _parent;  // ALWAYS weak_ptr to prevent cycles
+struct Child {
+    std::weak_ptr<Parent> _parent;  // weak_ptr if lifetime is uncertain and you made need to check null
+    // Parent* _parent;             // raw ptr preferred when parent is guaranteed to outlive child
 };
 ```
+
+**Raw pointer vs weak_ptr for back-references:** Use raw pointers in hot-path code (rendering, per-frame updates, audio) where the lifetime of the pointed-to object is well known and guaranteed. Use `weak_ptr` when the referenced object could genuinely become null during the code's lifetime and you need to check for that — `lock()` gives you a safe nullable handle.
 
 **Why This Matters:**
 - Prevents circular reference memory leaks
@@ -466,7 +468,83 @@ ork.asset.catalog.list.py      # Asset catalog listing
 - Python scripts in obt.project/bin
 - Any user-facing commands
 
+### Comment Separators
+
+Full-width (`////////////////////////////////////////////////////////////////////////////////`) separators are used between top-level declarations and method definitions. Half-width (`////////////////////////////////////////`) separators are used within method bodies to divide logical chunks of work. Named half-width blocks annotate significant categories of work within a method.
+
+**Header example:**
+```cpp
+////////////////////////////////////////////////////////////////////////////////
+namespace ork {
+////////////////////////////////////////////////////////////////////////////////
+
+struct CurrentState {
+  int _variable_name;
+  void methodName(int param_name);
+  void otherMethodName(int param_name);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct NextState {
+  int _variable_name;
+  void methodName(int param_name);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+} // namespace ork
+////////////////////////////////////////////////////////////////////////////////
+```
+
+**Implementation example:**
+```cpp
+////////////////////////////////////////////////////////////////////////////////
+namespace ork {
+////////////////////////////////////////////////////////////////////////////////
+
+void CurrentState::methodName(int param_name) {
+  // minor comment
+  ** logical chunk of work **
+
+  ////////////////////////////////////////
+
+  // minor comment
+  ** next logical chunk of work **
+
+  ////////////////////////////////////////
+  // Significant Named Category of Work
+  ////////////////////////////////////////
+
+  // minor comment
+  ** logical chunk of work **
+}
+
+void CurrentState::otherMethodName(int param_name) {
+  // minor comment
+  ** logical chunk of work **
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void NextState::methodName(int param_name) {
+
+  ////////////////////////////////////////
+  // Significant Named Category of Work
+  //  Note about category.
+  ////////////////////////////////////////
+
+  // minor comment
+  ** logical chunk of work **
+}
+
+////////////////////////////////////////////////////////////////////////////////
+} // namespace ork
+////////////////////////////////////////////////////////////////////////////////
+```
+
 ### C++ Conventions
+
+Always use `struct`, never `class`. All members are public by default — this is intentional. Access control is enforced by convention (underscore prefix for internal methods/members) not by language enforcement.
 
 ```cpp
 // Member variables with underscore prefix
@@ -548,6 +626,21 @@ py::class_<MyStruct, mystruct_ptr_t>(module, "MyStruct")
 - **Document expectations**: Make failure modes clear
 - **Python bindings**: Convert to exceptions where appropriate
 - **Resource management**: RAII everywhere, no manual cleanup
+
+### `_buildup()` / `_teardown()` Pattern
+
+Used for objects that need to be torn down and rebuilt mid-lifetime (e.g. swapchain recreation on window resize). The constructor calls `_buildup()` directly; the destructor calls `_teardown()`.
+
+**Error handling inside `_buildup()`:** Use `OrkAssert` for unrecoverable init failures. Do not throw.
+
+### `throw` vs `OrkAssert` — When to Use Which
+
+**Use `OrkAssert`** for unrecoverable engine/render/vulkan errors — hardware init failures, missing Vulkan functions, GPU allocation failures, invalid internal state. There are no catch blocks in the render pipeline; a `throw` here will call `std::terminate()` anyway, so `OrkAssert` is cleaner and more consistent.
+
+**Use `throw std::runtime_error`** only for errors that propagate to a known catch boundary:
+- Asset/catalog I/O operations (caught in `ork.core/src/asset/catalog/`)
+- Utility functions called from Python bindings (caught in `pyext_*.cpp`)
+- Network/crypto operations (caught in their respective utility wrappers)
 
 ## Architecture Principles
 

--- a/ork.data/misc/uncaught_exceptions.md
+++ b/ork.data/misc/uncaught_exceptions.md
@@ -1,0 +1,79 @@
+# Uncaught Exceptions Audit
+
+Generated: 2026-03-12
+
+## Critical — Will `std::terminate()` (no catch in call chain)
+
+### `ork.lev2/src/gfx/vulkan/vulkan_swapchain_drm.cpp`
+No catch blocks anywhere in file. All in methods called from `_buildup()`.
+
+| Line | Function | Message |
+|------|----------|---------|
+| 164 | `_createExportableImages()` | `"Required Vulkan function not available"` |
+| 173 | `_createExportableImages()` | `"No DRM modifiers available"` |
+| 211 | `_createExportableImages()` | `"No suitable DRM modifier found"` |
+| 228 | `_createExportableImages()` | `"Required Vulkan function not available"` |
+| 276 | `_createExportableImages()` | `"Failed to create Vulkan image"` |
+| 321 | `_createExportableImages()` | `"No suitable memory type found"` |
+| 327 | `_createExportableImages()` | `"Failed to allocate Vulkan memory"` |
+| 386 | `_exportImagesToDRM()` | `"Required Vulkan function not available"` |
+| 399 | `_exportImagesToDRM()` | `"Failed to export DMABUF"` |
+| 411 | `_exportImagesToDRM()` | `"Failed to import DMABUF to DRM"` |
+| 420 | `_exportImagesToDRM()` | `"Failed to create DRM framebuffer"` |
+| 480 | `_createRenderPass()` | `"Failed to create DRM render pass"` |
+| 514 | `_createImageViews()` | `"Failed to create DRM image view"` |
+| 556 | `_createFramebuffers()` | `"Failed to create DRM framebuffer"` |
+| 732 | `waitPresentFrame()` | `"SetCrtc failed"` |
+| 752 | `waitPresentFrame()` | `"Page flip failed"` |
+
+**Recommendation:** Replace all with `OrkAssert` for consistency with the rest of the vulkan codebase.
+
+### `ork.lev2/src/gfx/scenegraph/scenegraph.cpp`
+
+| Line | Function | Message |
+|------|----------|---------|
+| 396 | `configureCompositor()` | `"unknown compositor preset type"` |
+
+**Recommendation:** Replace with `OrkAssert`.
+
+### `ork.lev2/src/drm/drm_context.cpp`
+8 throws in `loadConfig()` during device enumeration.
+
+| Line | Message |
+|------|---------|
+| 338 | `"Failed to open any DRM device (/dev/dri/card*)"` |
+| 360 | `error_msg` (dynamic) |
+| 370 | `error_msg` (dynamic) |
+| 379 | `error_msg` (dynamic) |
+| 390 | `error_msg` (dynamic) |
+| 412 | `"Failed to get DRM resources"` |
+| 420 | `"Failed to get connector"` |
+| 444 | `"Failed to find CRTC"` |
+
+**Note:** `drm_context.cpp` has some local catch blocks — review whether these throws escape them before replacing.
+
+---
+
+## Probably Fine — Propagate to Python boundary
+
+These are in I/O/asset/utility paths eventually called from Python bindings, which do have `catch (const std::exception&)` handlers.
+
+| File | Count | Context |
+|------|-------|---------|
+| `ork.core/src/util/crypt.cpp` | 8 | Crypto encode/decode failures |
+| `ork.core/src/kernel/datablock.cpp` | 2 | LZ4 compress/decompress failures |
+| `ork.core/src/asset/catalog/entry.cpp` | 2 | Asset upload validation |
+| `ork.core/src/asset/catalog/chunk_manifest.cpp` | 1 | JSON parse error |
+| `ork.core/src/python/pycodec_pybind11.cpp` | 4 | Unregistered codec type |
+
+---
+
+## Known Catch Sites (for reference)
+
+| File | Scope |
+|------|-------|
+| `ork.core/src/application/application.cpp:493` | Only wraps `onAppShutdown()` |
+| `ork.core/src/kernel/thread.cpp:42` | Thread entry point |
+| `pyext_*.cpp` (many) | Python/C++ boundary |
+| `ork.core/src/asset/catalog/*.cpp` | Asset I/O operations |
+| `ork.core/src/util/upload_https.cpp` | Network I/O |


### PR DESCRIPTION
I added a few more items to the sessions notes to clarify things about assert and exception usage. Buildup and teardown methods. Then weak_ptr and raw ptr usage. If those look good to you, I think they'd be good to add.

I also ran an analysis to track down every throw which is not currently being dealt with. This is output in exception_analysis. At some point should go through and make the use of throw and assert consistent. Get rid of the throws which are not caught anywhere and change those to asserts. Then make all the Vulkan code use OrkVkAssert.