### PR TITLE
Remove swap min assert.

### DIFF
--- a/ork.lev2/src/gfx/vulkan/vulkan_swapchain.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_swapchain.cpp
@@ -137,7 +137,6 @@ void VkSwapChain::_buildup() {
   // image properties
   // Ensure minImageCount is within capabilities
   uint32_t minImageCount = MAX_FRAMES_IN_FLIGHT;
-  OrkAssertI(minImageCount >= caps.minImageCount, "minImageCount is below caps.minImageCount");
   OrkAssertI(minImageCount <= caps.maxImageCount, "minImageCount exceeds caps.maxImageCount");
   SCINFO.minImageCount    = minImageCount;
   SCINFO.imageFormat      = surfaceFormat.format;                // Chosen from VkSurfaceFormatKHR, after querying supported formats


### PR DESCRIPTION
This does not need to be asserted. 

SCINFO.minImageCount is a requested count not an exact count. It will return whatever count is correct. 

And there is a condition on my AMD machine where the minImageCount assert does fail. Might happen on others.