### PR TITLE
FilesystemView: close gaps for Figma-driven card UI

### DIFF
--- a/obt.project/scripts/ork/app/testrunner.py
+++ b/obt.project/scripts/ork/app/testrunner.py
@@ -415,7 +415,7 @@ class TestRunnerFilesystemModel(lev2.ui.FilesystemModel):
               '<path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" fill="%s"/>' % color
             )
     if svg_string:
-      return icon_library.from_svg_string(svg_string, size, size)
+      return icon_library.from_svg_string_auto(svg_string, size)
     return None
 
   def getIconSequence(self, path, size=64):

--- a/obt.project/scripts/ork/ui/icon_library.py
+++ b/obt.project/scripts/ork/ui/icon_library.py
@@ -48,6 +48,34 @@ def text_icon(text, width=24, height=24, font_size=12, color="#E6E6E6"):
 
 ################################################################################
 
+def from_svg_string_auto(svg_string, width):
+  """
+  Render an SVG string to an RGBA image, preserving aspect ratio.
+  Width is fixed; height is derived from the SVG viewBox.
+  Falls back to square if viewBox is absent or square.
+
+  Args:
+    svg_string: SVG markup as a string
+    width: Output width in pixels
+
+  Returns:
+    lev2.Image (image_ptr_t)
+  """
+  height = width  # default: square
+  vb_start = svg_string.find('viewBox="')
+  if vb_start >= 0:
+    vb_start += len('viewBox="')
+    vb_end = svg_string.find('"', vb_start)
+    parts = svg_string[vb_start:vb_end].split()
+    if len(parts) == 4:
+      vb_w = float(parts[2])
+      vb_h = float(parts[3])
+      if vb_w > 0:
+        height = int(width * vb_h / vb_w)
+  return from_svg_string(svg_string, width, height)
+
+################################################################################
+
 def from_svg_string(svg_string, width, height):
   """
   Render an SVG string to an RGBA image.

--- a/ork.lev2/inc/ork/lev2/ui/filesystem_view.h
+++ b/ork.lev2/inc/ork/lev2/ui/filesystem_view.h
@@ -150,6 +150,8 @@ struct FilesystemView : public Group {
   std::function<void(const std::string& path)> _onDelete;
   std::function<void(const std::string& old_path, const std::string& new_name)> _onRename;
   std::function<void(const std::string& path, int screen_x, int screen_y)> _onContextMenu;
+  std::function<void(const std::string& path)> _onHover;
+
 
   //////////////////////////////////////////////////////////////
   // Appearance - List mode
@@ -177,6 +179,8 @@ struct FilesystemView : public Group {
   int _icon_size = 64;
   int _icon_spacing = 8;
   int _icon_label_height = 32;
+  bool _icon_center_h = false;  // center icon grid horizontally
+  bool _icon_center_v = false;  // center icon grid vertically
 
   //////////////////////////////////////////////////////////////
   // Appearance - Common
@@ -212,6 +216,7 @@ struct FilesystemView : public Group {
   void _updateIconCache(lev2::Context* ctx, const std::string& path, int size);
   lev2::texture_ptr_t _getIconForPath(lev2::Context* ctx, const std::string& path, FileType type, int size);
   void clearIconCache() { _icon_cache.clear(); _folder_icon_texture = nullptr; _file_icon_texture = nullptr; }
+  void clearIconCacheForPath(const std::string& path) { _icon_cache.erase(path); }
 
   //////////////////////////////////////////////////////////////
   // Composition (sub-widgets)

--- a/ork.lev2/pyext/src/pyext_ui_filesystem.cpp
+++ b/ork.lev2/pyext/src/pyext_ui_filesystem.cpp
@@ -753,6 +753,14 @@ void pyinit_ui_filesystem(py::module& uimodule) {
                   callback(path, x, y);
                 };
               })
+          .def(
+              "onHover",
+              [](ui::filesystem_view_ptr_t view, py::object callback) { //
+                view->_onHover = [callback](const std::string& path) {
+                  py::gil_scoped_acquire acquire;
+                  callback(path);
+                };
+              })
           // Appearance - List mode
           .def_readwrite("item_height", &ui::FilesystemView::_item_height)
           .def_readwrite("icon_column_width", &ui::FilesystemView::_icon_column_width)
@@ -771,6 +779,8 @@ void pyinit_ui_filesystem(py::module& uimodule) {
           .def_readwrite("icon_size", &ui::FilesystemView::_icon_size)
           .def_readwrite("icon_spacing", &ui::FilesystemView::_icon_spacing)
           .def_readwrite("icon_label_height", &ui::FilesystemView::_icon_label_height)
+          .def_readwrite("icon_center_h", &ui::FilesystemView::_icon_center_h)
+          .def_readwrite("icon_center_v", &ui::FilesystemView::_icon_center_v)
           .def_readwrite("icon_anim_fps", &ui::FilesystemView::_icon_anim_fps)
           // Appearance - Common
           .def_property(
@@ -868,6 +878,9 @@ void pyinit_ui_filesystem(py::module& uimodule) {
               "Default file icon image (converted to texture lazily)")
           .def("clearIconCache", &ui::FilesystemView::clearIconCache,
               "Clear the icon cache (useful after directory change)")
+          .def("clearIconCacheForPath", &ui::FilesystemView::clearIconCacheForPath,
+              py::arg("path"),
+              "Clear cached icon for a specific path only")
           .def(
               "addToolbar",
               [](ui::filesystem_view_ptr_t view, const std::string& name, int height) -> ui::toolbar_ptr_t {

--- a/ork.lev2/src/ui/widgets/filesystem_view.cpp
+++ b/ork.lev2/src/ui/widgets/filesystem_view.cpp
@@ -499,8 +499,11 @@ HandlerResult ContentWidget::DoOnUiEvent(event_constptr_t ev) {
 
     case EventCode::MOVE: {
       std::string hovered_path = _fsview->_getItemPathAt(localX, localY);
-      if (!hovered_path.empty() && _fsview->_hovered_path != hovered_path) {
+      if (_fsview->_hovered_path != hovered_path) {
         _fsview->_hovered_path = hovered_path;
+        if (_fsview->_onHover) {
+          _fsview->_onHover(hovered_path);
+        }
       }
       break;
     }
@@ -898,9 +901,15 @@ int FilesystemView::_getItemIndexAt(int local_x, int local_y) const {
     int cell_width = _icon_size + _icon_spacing;
     int cell_height = _icon_size + _icon_label_height + _icon_spacing;
     int cols = std::max(1, available_width / cell_width);
-    int col = (local_x - _icon_spacing) / cell_width;
-    int row = content_y / cell_height;
-    if (col >= 0 && col < cols) {
+    int rows = ((int)_visible_items.size() + cols - 1) / cols;
+    int items_in_first_row = std::min((int)_visible_items.size(), cols);
+    int grid_width = items_in_first_row * cell_width - _icon_spacing;
+    int grid_height = rows * cell_height;
+    int x_offset = _icon_center_h ? std::max(0, (_geometry._w - grid_width) / 2) : _icon_spacing;
+    int y_offset = _icon_center_v ? std::max(0, ((_content_widget ? _content_widget->height() : _geometry._h) - grid_height) / 2) : 0;
+    int col = (local_x - x_offset) / cell_width;
+    int row = (content_y - y_offset) / cell_height;
+    if (col >= 0 && col < cols && row >= 0) {
       int index = row * cols + col;
       if (index >= 0 && index < (int)_visible_items.size()) return index;
     }
@@ -1135,13 +1144,21 @@ void FilesystemView::_drawContentIconMode(drawevent_constptr_t drwev) {
     int cell_width = _icon_size + _icon_spacing;
     int cell_height = _icon_size + _icon_label_height + _icon_spacing;
     int cols = std::max(1, available_width / cell_width);
+    int rows = ((int)_visible_items.size() + cols - 1) / cols;
+
+    // Centering offsets
+    int items_in_first_row = std::min((int)_visible_items.size(), cols);
+    int grid_width = items_in_first_row * cell_width - _icon_spacing;
+    int grid_height = rows * cell_height;
+    int x_offset = _icon_center_h ? std::max(0, (_geometry._w - grid_width) / 2) : _icon_spacing;
+    int y_offset = _icon_center_v ? std::max(0, (_content_widget->height() - grid_height) / 2) : 0;
 
     for (size_t i = 0; i < _visible_items.size(); i++) {
       int col = i % cols;
       int row = i / cols;
 
-      int item_x = ix1 + _icon_spacing + col * cell_width;
-      int item_y = iy1 - _scroll_offset + row * cell_height;
+      int item_x = ix1 + x_offset + col * cell_width;
+      int item_y = iy1 + y_offset - _scroll_offset + row * cell_height;
 
       if (item_y + cell_height < iy1) continue;
       if (item_y > iy2) break;
@@ -1359,9 +1376,19 @@ void FilesystemView::_drawIconItem(drawevent_constptr_t drwev, const VisibleItem
       fxi->pushRasterState(rs);
       tgt->PushModColor(fvec4(1, 1, 1, 1));
       _tex_material->SetTexture(lev2::ETEXDEST_DIFFUSE, icon_texture.get());
+
+      // Respect texture aspect ratio: tall textures extend below the icon cell
+      int icon_w = _icon_size - 8;
+      int icon_h = icon_w;
+      int tex_w = icon_texture->_width;
+      int tex_h = icon_texture->_height;
+      if (tex_w > 0 && tex_h > tex_w) {
+        icon_h = icon_w * tex_h / tex_w;
+      }
+
       primi->RenderQuadAtZ(_tex_material.get(),
-                           x_pos + 4, x_pos + _icon_size - 4,
-                           y_pos + 4, y_pos + _icon_size - 4,
+                           x_pos + 4, x_pos + 4 + icon_w,
+                           y_pos + 4, y_pos + 4 + icon_h,
                            0.0f, 0.0f, 1.0f, 0.0f, 1.0f);
       tgt->PopModColor();
       fxi->popRasterState();


### PR DESCRIPTION
## Summary
- `onHover` Python callback for hover state transitions
- `clearIconCacheForPath` for single-item cache invalidation (eliminates flash on hover)
- `icon_center_h` / `icon_center_v` properties for centered icon grids
- Aspect-ratio aware icon rendering (tall textures extend below cell)
- `from_svg_string_auto` preserves SVG viewBox aspect ratio

## Test plan
- [ ] Build orkid
- [ ] Run testrunner. Cards should be centered, hover should change icon colors without flash