### PR TITLE
ork.ui.figma: FigmaDesign class for Figma JSON to orkid SVG pipeline

### DIFF
--- a/obt.project/scripts/ork/app/testrunner.py
+++ b/obt.project/scripts/ork/app/testrunner.py
@@ -415,7 +415,7 @@ class TestRunnerFilesystemModel(lev2.ui.FilesystemModel):
               '<path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" fill="%s"/>' % color
             )
     if svg_string:
-      return icon_library.from_svg_string(svg_string, size, size)
+      return icon_library.from_svg_string_auto(svg_string, size)
     return None
 
   def getIconSequence(self, path, size=64):

--- a/obt.project/scripts/ork/ui/figma/__init__.py
+++ b/obt.project/scripts/ork/ui/figma/__init__.py
@@ -1,0 +1,18 @@
+"""
+ork.ui.figma — Figma JSON → SVG conversion and structured design access.
+
+Two main entry points:
+
+  FigmaDesign(path)
+      Load a Figma REST API JSON export and query pages, frames,
+      sections, and elements by name.  Convert any node or region
+      to SVG deterministically.
+
+  figma_node_to_svg(node)
+      Low-level: convert a raw Figma JSON node dict to SVG markup.
+"""
+
+from ork.ui.figma.design import FigmaDesign, FigmaNode, FigmaPage, FigmaSection, FigmaFrame, CardRegion, PanelSpec
+from ork.ui.figma.converter import figma_node_to_svg, figma_children_to_svg_fragment
+from ork.ui.figma.shapes import person_silhouette_svg, multi_person_svg, circle_icon_svg
+from ork.ui.figma.card import build_card_svg

--- a/obt.project/scripts/ork/ui/figma/card.py
+++ b/obt.project/scripts/ork/ui/figma/card.py
@@ -1,0 +1,90 @@
+"""
+Generic rounded-rect card SVG builder.
+
+Generates a card with configurable color, corner radius, drop shadow,
+and an optional centered icon.  Apps supply all visual parameters —
+no design-specific constants live here.
+"""
+
+from ork.ui.figma.shapes import (
+    person_silhouette_svg,
+    multi_person_svg,
+    circle_icon_svg,
+)
+
+# Registry of built-in icon type renderers.
+# Each takes (color, cx, cy, scale, icon_scale) and returns SVG fragment.
+# icon_scale is the caller-supplied multiplier for the icon within the card.
+_ICON_RENDERERS = {
+    "person":       lambda c, cx, cy, s, iscale: person_silhouette_svg(c, cx=cx, cy=cy, scale=s * iscale),
+    "multi_person": lambda c, cx, cy, s, iscale: multi_person_svg(c, cx=cx, cy=cy, scale=s * iscale, count=3),
+    "circle":       lambda c, cx, cy, s, iscale: circle_icon_svg(c, cx=cx, cy=cy, r=iscale * s),
+}
+
+
+def build_card_svg(card_color, icon_color, icon_type="person", size=300,
+                   corner_radius=40, shadow_dy=4, shadow_blur=8, shadow_opacity=0.25,
+                   label=None, label_color="#FFFFFF", label_font_size=20,
+                   label_bottom_offset=51,
+                   icon_cy_offset=0, icon_scale=1.0):
+    """Build an SVG string for a rounded-rect card with optional icon and label.
+
+    Args:
+        card_color: Fill color for the card background.
+        icon_color: Fill color for the centered icon.
+        icon_type: Key in _ICON_RENDERERS, or "none" for no icon.
+                   Can also pass a callable(color, cx, cy, scale)->str.
+        size: Card dimension in pixels (square).
+        corner_radius: Corner radius (at size=300 reference; scales proportionally).
+        shadow_dy: Drop shadow Y offset.
+        shadow_blur: Drop shadow blur radius (stdDeviation).
+        shadow_opacity: Drop shadow opacity.
+        label: Text to render inside the card near the bottom. None = no label.
+        label_color: Fill color for the label text.
+        label_font_size: Font size (at size=300 reference; scales proportionally).
+        label_bottom_offset: Distance from card bottom to label baseline
+                             (at size=300 reference; scales proportionally).
+        icon_cy_offset: Vertical offset for the icon center (at size=300 reference).
+                        Negative = up. Useful when label occupies the bottom.
+        icon_scale: Scale multiplier for the icon shape within the card.
+                    Meaning depends on icon_type (e.g. person scale, circle radius).
+
+    Returns:
+        Complete SVG markup string.
+    """
+    s = size / 300  # master scale factor (300 = reference size)
+    r = corner_radius * s
+    cx = size / 2
+    cy = size / 2 + icon_cy_offset * s
+
+    if callable(icon_type):
+        icon_svg = icon_type(icon_color, cx, cy, s)
+    elif icon_type in _ICON_RENDERERS:
+        icon_svg = _ICON_RENDERERS[icon_type](icon_color, cx, cy, s, icon_scale)
+    else:
+        icon_svg = ""
+
+    label_svg = ""
+    if label:
+        fs = label_font_size * s
+        ly = size - label_bottom_offset * s + fs * 0.35  # baseline adjust
+        label_svg = (
+            f'<text x="{cx}" y="{ly}" text-anchor="middle" '
+            f'font-family="Roboto Mono, monospace" font-size="{fs}" '
+            f'fill="{label_color}">{label}</text>'
+        )
+
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {size} {size}">'
+        f'<defs>'
+        f'<filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">'
+        f'<feDropShadow dx="0" dy="{shadow_dy}" stdDeviation="{shadow_blur}" '
+        f'flood-color="#000000" flood-opacity="{shadow_opacity}"/>'
+        f'</filter>'
+        f'</defs>'
+        f'<rect x="0" y="0" width="{size}" height="{size}" rx="{r}" ry="{r}" '
+        f'fill="{card_color}" filter="url(#shadow)"/>'
+        f'{icon_svg}'
+        f'{label_svg}'
+        f'</svg>'
+    )

--- a/obt.project/scripts/ork/ui/figma/converter.py
+++ b/obt.project/scripts/ork/ui/figma/converter.py
@@ -1,0 +1,425 @@
+"""
+ork.ui.figma.converter — Deterministic Figma JSON node → SVG converter.
+
+Converts Figma node trees (as parsed from the Figma REST API JSON) into
+SVG markup.  Handles the node types used in card-based UI designs:
+
+  FRAME, RECTANGLE, VECTOR (ellipse), TEXT, BOOLEAN_OPERATION, INSTANCE, GROUP
+
+When the JSON is fetched with geometry=paths, fillGeometry SVG path data
+is used for pixel-perfect rendering.  Otherwise, bounding-box fallbacks
+are used.
+"""
+
+
+def _figma_color_to_hex(color_dict):
+    """Convert Figma color dict {r, g, b, a} to '#RRGGBB'."""
+    r = int(color_dict.get("r", 0) * 255)
+    g = int(color_dict.get("g", 0) * 255)
+    b = int(color_dict.get("b", 0) * 255)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _get_solid_fill(node):
+    """Return the first visible SOLID fill hex color, or None."""
+    for fill in node.get("fills", []):
+        if fill.get("type") == "SOLID" and fill.get("visible", True):
+            return _figma_color_to_hex(fill["color"])
+    return None
+
+
+def _get_solid_stroke(node):
+    """Return the first visible SOLID stroke hex color, or None."""
+    for stroke in node.get("strokes", []):
+        if stroke.get("type") == "SOLID" and stroke.get("visible", True):
+            return _figma_color_to_hex(stroke["color"])
+    return None
+
+
+_stroke_clip_counter = [0]
+
+def _render_stroke(node, ox, oy, stroke_color):
+    """Render a node's stroke as an SVG stroke on its fillGeometry path.
+
+    For strokeAlign=INSIDE: uses double stroke-width clipped to the shape.
+    For strokeAlign=CENTER (default): uses stroke-width as-is.
+    For strokeAlign=OUTSIDE: uses double stroke-width with inverse clip.
+    """
+    fill_geom = node.get("fillGeometry", [])
+    if not fill_geom:
+        return None
+
+    stroke_weight = node.get("strokeWeight", 1)
+    stroke_align = node.get("strokeAlign", "CENTER")
+    bbox = node["absoluteBoundingBox"]
+    x = bbox["x"] - ox
+    y = bbox["y"] - oy
+
+    parts = []
+    for geom in fill_geom:
+        path_data = geom.get("path", "")
+        if not path_data:
+            continue
+
+        if stroke_align == "INSIDE":
+            clip_id = f"sc{_stroke_clip_counter[0]}"
+            _stroke_clip_counter[0] += 1
+            parts.append(
+                f'<defs><clipPath id="{clip_id}">'
+                f'<path d="{path_data}" transform="translate({x},{y})"/>'
+                f'</clipPath></defs>'
+                f'<g clip-path="url(#{clip_id})">'
+                f'<path d="{path_data}" fill="none" stroke="{stroke_color}" '
+                f'stroke-width="{stroke_weight * 2}" '
+                f'transform="translate({x},{y})"/>'
+                f'</g>'
+            )
+        else:
+            parts.append(
+                f'<path d="{path_data}" fill="none" stroke="{stroke_color}" '
+                f'stroke-width="{stroke_weight}" '
+                f'transform="translate({x},{y})"/>'
+            )
+
+    return "\n".join(parts) if parts else None
+
+
+def _svg_drop_shadow(effect, filter_id="shadow"):
+    """Convert a Figma DROP_SHADOW effect to an SVG filter definition."""
+    offset = effect.get("offset", {})
+    dx = offset.get("x", 0)
+    dy = offset.get("y", 0)
+    radius = effect.get("radius", 0)
+    color = effect.get("color", {})
+    opacity = color.get("a", 0.25)
+    return (
+        f'<filter id="{filter_id}" x="-20%" y="-20%" width="140%" height="150%">'
+        f'<feDropShadow dx="{dx}" dy="{dy}" stdDeviation="{radius / 2}" '
+        f'flood-color="{_figma_color_to_hex(color)}" flood-opacity="{opacity}"/>'
+        f'</filter>'
+    )
+
+
+# -------------------------------------------------------------------------
+# Shape rendering — uses fillGeometry paths when available
+# -------------------------------------------------------------------------
+
+def _render_fill_geometry(node, ox, oy, fill):
+    """Render a node using its fillGeometry SVG path data.
+
+    Returns SVG string if fillGeometry is present, else None.
+    """
+    fill_geom = node.get("fillGeometry", [])
+    if not fill_geom:
+        return None
+
+    bbox = node["absoluteBoundingBox"]
+    x = bbox["x"] - ox
+    y = bbox["y"] - oy
+
+    paths = []
+    for geom in fill_geom:
+        path_data = geom.get("path", "")
+        if path_data:
+            wind = geom.get("windingRule", "NONZERO")
+            fill_rule = "evenodd" if wind == "EVENODD" else "nonzero"
+            paths.append(
+                f'<path d="{path_data}" fill="{fill}" '
+                f'fill-rule="{fill_rule}" '
+                f'transform="translate({x},{y})"/>'
+            )
+    return "\n".join(paths) if paths else None
+
+
+def _convert_shape(node, ox, oy, fill_override=None):
+    """Convert a shape node (RECTANGLE, VECTOR, ELLIPSE) to SVG.
+
+    Prefers fillGeometry paths when available for exact rendering.
+    Falls back to bounding-box approximations otherwise.
+    """
+    fill = fill_override or _get_solid_fill(node)
+    if fill is None:
+        return ""
+
+    # Prefer fillGeometry for all shape types
+    svg = _render_fill_geometry(node, ox, oy, fill)
+    if svg:
+        return svg
+
+    # Fallback: bounding-box based rendering
+    node_type = node.get("type", "")
+    bbox = node["absoluteBoundingBox"]
+    x = bbox["x"] - ox
+    y = bbox["y"] - oy
+    w = bbox["width"]
+    h = bbox["height"]
+
+    if node_type == "RECTANGLE":
+        r = node.get("cornerRadius", 0)
+        rot = node.get("rotation", 0)
+        attrs = f'x="{x}" y="{y}" width="{w}" height="{h}"'
+        if r:
+            attrs += f' rx="{r}" ry="{r}"'
+        attrs += f' fill="{fill}"'
+        if abs(rot) > 0.001:
+            cx = x + w / 2
+            cy = y + h / 2
+            return f'<rect {attrs} transform="rotate({-rot} {cx} {cy})"/>'
+        return f'<rect {attrs}/>'
+
+    else:  # VECTOR, ELLIPSE
+        cx = x + w / 2
+        cy = y + h / 2
+        rx = w / 2
+        ry = h / 2
+        return f'<ellipse cx="{cx}" cy="{cy}" rx="{rx}" ry="{ry}" fill="{fill}"/>'
+
+
+# -------------------------------------------------------------------------
+# Text rendering
+# -------------------------------------------------------------------------
+
+def _convert_text(node, ox, oy):
+    """Convert a Figma TEXT node to SVG text element."""
+    bbox = node["absoluteBoundingBox"]
+    x = bbox["x"] - ox
+    y = bbox["y"] - oy
+    w = bbox["width"]
+    h = bbox["height"]
+    fill = _get_solid_fill(node) or "#FFFFFF"
+    text = node.get("characters", "")
+    style = node.get("style", {})
+    font_family = style.get("fontFamily", "sans-serif")
+    font_size = style.get("fontSize", 16)
+    font_weight = style.get("fontWeight", 400)
+    h_align = style.get("textAlignHorizontal", "LEFT")
+    v_align = style.get("textAlignVertical", "TOP")
+
+    if h_align == "CENTER":
+        tx = x + w / 2
+        anchor = "middle"
+    elif h_align == "RIGHT":
+        tx = x + w
+        anchor = "end"
+    else:
+        tx = x
+        anchor = "start"
+
+    if v_align == "CENTER":
+        ty = y + h / 2 + font_size * 0.35
+    elif v_align == "BOTTOM":
+        ty = y + h
+    else:
+        ty = y + font_size * 0.85
+
+    weight_attr = f' font-weight="{font_weight}"' if font_weight != 400 else ''
+
+    lines = text.split("\n")
+    if len(lines) == 1:
+        return (
+            f'<text x="{tx}" y="{ty}" text-anchor="{anchor}" '
+            f'font-family="{font_family}, monospace" font-size="{font_size}"'
+            f'{weight_attr} fill="{fill}">{text}</text>'
+        )
+    else:
+        tspans = []
+        for i, line in enumerate(lines):
+            line_y = ty + i * font_size * 1.2
+            tspans.append(f'<tspan x="{tx}" y="{line_y}">{line}</tspan>')
+        return (
+            f'<text text-anchor="{anchor}" '
+            f'font-family="{font_family}, monospace" font-size="{font_size}"'
+            f'{weight_attr} fill="{fill}">{"".join(tspans)}</text>'
+        )
+
+
+# -------------------------------------------------------------------------
+# Boolean operations
+# -------------------------------------------------------------------------
+
+_bool_id_counter = [0]
+
+def _convert_boolean_operation(node, ox, oy):
+    """Convert a Figma BOOLEAN_OPERATION (UNION) to SVG.
+
+    Strategy: render all child shapes into a clipPath, then fill through
+    the clip. This produces a true boolean union with no seams.
+
+    When fillGeometry is available on the BOOLEAN_OPERATION node itself,
+    we use that directly (it's the pre-computed union outline).
+    """
+    fill = _get_solid_fill(node)
+    if fill is None:
+        return ""
+
+    # If the boolean op node itself has fillGeometry, use it directly
+    # (this is the computed union as SVG paths)
+    fg = node.get("fillGeometry", [])
+    if fg:
+        bbox = node["absoluteBoundingBox"]
+        x = bbox["x"] - ox
+        y = bbox["y"] - oy
+        paths = []
+        for geom in fg:
+            path_data = geom.get("path", "")
+            if path_data:
+                wind = geom.get("windingRule", "NONZERO")
+                fill_rule = "evenodd" if wind == "EVENODD" else "nonzero"
+                paths.append(
+                    f'<path d="{path_data}" fill="{fill}" '
+                    f'fill-rule="{fill_rule}" '
+                    f'transform="translate({x},{y})"/>'
+                )
+        if paths:
+            return "\n".join(paths)
+
+    # Fallback: clipPath approach from child shapes
+    clip_parts = []
+    for child in node.get("children", []):
+        child_type = child.get("type", "")
+        if child_type in ("GROUP", "INSTANCE"):
+            for grandchild in child.get("children", []):
+                clip_parts.append(_convert_shape(grandchild, ox, oy, fill_override="white"))
+        else:
+            clip_parts.append(_convert_shape(child, ox, oy, fill_override="white"))
+
+    clip_svg = "\n".join(p for p in clip_parts if p)
+    if not clip_svg:
+        return ""
+
+    clip_id = f"bool{_bool_id_counter[0]}"
+    _bool_id_counter[0] += 1
+
+    bbox = node["absoluteBoundingBox"]
+    x = bbox["x"] - ox
+    y = bbox["y"] - oy
+    w = bbox["width"]
+    h = bbox["height"]
+    pad = 2
+    rx, ry, rw, rh = x - pad, y - pad, w + pad * 2, h + pad * 2
+
+    return (
+        f'<defs><clipPath id="{clip_id}">{clip_svg}</clipPath></defs>'
+        f'<rect x="{rx}" y="{ry}" width="{rw}" height="{rh}" '
+        f'fill="{fill}" clip-path="url(#{clip_id})"/>'
+    )
+
+
+# -------------------------------------------------------------------------
+# Public API
+# -------------------------------------------------------------------------
+
+def figma_node_to_svg(node, width=None, height=None):
+    """Convert a Figma node tree to a complete SVG document string."""
+    bbox = node["absoluteBoundingBox"]
+    ox = bbox["x"]
+    oy = bbox["y"]
+    w = width or bbox["width"]
+    h = height or bbox["height"]
+
+    # Collect filter definitions from effects
+    defs_parts = []
+    filter_id_counter = [0]
+
+    def _collect_effects(n):
+        for effect in n.get("effects", []):
+            if effect.get("type") == "DROP_SHADOW" and effect.get("visible", True):
+                fid = f"shadow{filter_id_counter[0]}"
+                filter_id_counter[0] += 1
+                defs_parts.append(_svg_drop_shadow(effect, fid))
+                n["_svg_filter_id"] = fid
+        for child in n.get("children", []):
+            _collect_effects(child)
+
+    _collect_effects(node)
+
+    defs_svg = ""
+    if defs_parts:
+        defs_svg = "<defs>" + "".join(defs_parts) + "</defs>"
+
+    body_parts = []
+    _render_children(node, ox, oy, body_parts)
+    body_svg = "\n".join(body_parts)
+
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}">'
+        f'{defs_svg}'
+        f'{body_svg}'
+        f'</svg>'
+    )
+
+
+def figma_children_to_svg_fragment(node, ox, oy):
+    """Convert a node's children to SVG fragment (no <svg> wrapper)."""
+    parts = []
+    _render_children(node, ox, oy, parts)
+    return "\n".join(parts)
+
+
+def _render_children(node, ox, oy, parts):
+    """Recursively render a node's children into SVG parts list."""
+    for child in node.get("children", []):
+        _render_node(child, ox, oy, parts)
+
+
+def _render_node(node, ox, oy, parts):
+    """Render a single Figma node to SVG and append to parts."""
+    node_type = node.get("type", "")
+    visible = node.get("visible", True)
+    if not visible:
+        return
+
+    filter_attr = ""
+    if "_svg_filter_id" in node:
+        filter_attr = f' filter="url(#{node["_svg_filter_id"]})"'
+
+    if node_type in ("RECTANGLE", "VECTOR", "ELLIPSE"):
+        shape_parts = []
+
+        fill = _get_solid_fill(node)
+        stroke = _get_solid_stroke(node)
+
+        if fill is not None:
+            # Has a fill color — render the fill
+            fg_svg = _render_fill_geometry(node, ox, oy, fill)
+            if fg_svg:
+                shape_parts.append(fg_svg)
+            else:
+                svg = _convert_shape(node, ox, oy)
+                if svg:
+                    shape_parts.append(svg)
+
+        if stroke is not None:
+            # Render strokeGeometry (pre-computed stroke outline) as filled path
+            sg_svg = _render_stroke(node, ox, oy, stroke)
+            if sg_svg:
+                shape_parts.append(sg_svg)
+
+        if shape_parts:
+            combined = "\n".join(shape_parts)
+            if filter_attr:
+                parts.append(f'<g{filter_attr}>{combined}</g>')
+            else:
+                parts.append(combined)
+
+    elif node_type == "TEXT":
+        parts.append(_convert_text(node, ox, oy))
+
+    elif node_type == "BOOLEAN_OPERATION":
+        parts.append(_convert_boolean_operation(node, ox, oy))
+
+    elif node_type in ("FRAME", "GROUP", "INSTANCE", "SECTION"):
+        fill = _get_solid_fill(node)
+        if fill is not None:
+            bbox = node["absoluteBoundingBox"]
+            x = bbox["x"] - ox
+            y = bbox["y"] - oy
+            w = bbox["width"]
+            h = bbox["height"]
+            r = node.get("cornerRadius", 0)
+            attrs = f'x="{x}" y="{y}" width="{w}" height="{h}"'
+            if r:
+                attrs += f' rx="{r}" ry="{r}"'
+            attrs += f' fill="{fill}"{filter_attr}'
+            parts.append(f'<rect {attrs}/>')
+        _render_children(node, ox, oy, parts)

--- a/obt.project/scripts/ork/ui/figma/design.py
+++ b/obt.project/scripts/ork/ui/figma/design.py
@@ -1,0 +1,476 @@
+"""
+ork.ui.figma.design — FigmaDesign class for structured access to Figma exports.
+
+Load a Figma REST API JSON export once, then query pages, frames, and
+elements by name.  Convert any node or region to SVG deterministically.
+
+Provides frame comparison methods to derive hover colors, icon colors,
+panel specs, and card regions — all from the Figma data itself.
+
+Usage::
+
+    design = FigmaDesign("/path/to/figma.json")
+    page = design.page("UI_V2")
+    section = page.section("UI_V2")
+    default = section.frame("Default_State")
+    hover = section.frame("Hover_State")
+    selected = section.frame("Selected_State")
+
+    # Detect cards (large rounded rects)
+    cards = default.detect_cards()
+
+    # Extract card SVGs
+    svgs = default.extract_card_svgs(cards)
+
+    # Derive hover color by comparing frames
+    hover_color = default.derive_hover_color(hover)
+
+    # Get icon colors per card region
+    icon_colors = default.icon_colors_in_region(card)
+
+    # Build hover SVG by replacing icon colors
+    hover_svg = default.make_hover_svg(card, hover_color)
+
+    # Extract panel specs from selected frame
+    panel = selected.detect_panel(cards)
+
+    # Build selected SVG (hover card + panel)
+    selected_svg = default.make_selected_svg(card, hover_color, panel, "description")
+"""
+
+import json
+from pathlib import Path
+
+from ork.ui.figma.converter import (
+    figma_node_to_svg,
+    _get_solid_fill,
+    _get_solid_stroke,
+    _figma_color_to_hex,
+)
+
+
+# -------------------------------------------------------------------------
+# Card region descriptor
+# -------------------------------------------------------------------------
+
+class CardRegion:
+    """A detected card region in a frame."""
+    def __init__(self, x, y, w, h, bg_color=None):
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+        self.bg_color = bg_color
+
+    def __repr__(self):
+        return f"CardRegion({self.x}, {self.y}, {self.w}x{self.h}, bg={self.bg_color})"
+
+
+# -------------------------------------------------------------------------
+# Panel descriptor
+# -------------------------------------------------------------------------
+
+class PanelSpec:
+    """Description panel specs derived from a selected-state frame."""
+    def __init__(self):
+        self.gap = 32         # gap between card bottom and panel top
+        self.width = 300
+        self.height = 263
+        self.corner_radius = 40
+        self.fill = "#efefef"
+        self.stroke = "#212121"
+        self.stroke_width = 2
+        self.text_fill = "#494949"
+        self.text_size = 16
+        self.text_offset_x = 33
+        self.text_offset_y = 37
+
+
+# -------------------------------------------------------------------------
+# FigmaNode
+# -------------------------------------------------------------------------
+
+class FigmaNode:
+    """Wrapper around a raw Figma JSON node dict."""
+
+    def __init__(self, data, root_design=None):
+        self._data = data
+        self._design = root_design
+
+    @property
+    def name(self):
+        return self._data.get("name", "")
+
+    @property
+    def type(self):
+        return self._data.get("type", "")
+
+    @property
+    def bbox(self):
+        b = self._data.get("absoluteBoundingBox", {})
+        return b.get("x", 0), b.get("y", 0), b.get("width", 0), b.get("height", 0)
+
+    @property
+    def width(self):
+        return self._data.get("absoluteBoundingBox", {}).get("width", 0)
+
+    @property
+    def height(self):
+        return self._data.get("absoluteBoundingBox", {}).get("height", 0)
+
+    @property
+    def fill_color(self):
+        return _get_solid_fill(self._data)
+
+    @property
+    def background_color(self):
+        bg = self._data.get("backgroundColor")
+        if bg:
+            return _figma_color_to_hex(bg)
+        return self.fill_color
+
+    @property
+    def corner_radius(self):
+        return self._data.get("cornerRadius", 0)
+
+    @property
+    def rotation(self):
+        return self._data.get("rotation", 0)
+
+    @property
+    def text(self):
+        return self._data.get("characters", "")
+
+    @property
+    def font_size(self):
+        return self._data.get("style", {}).get("fontSize", 0)
+
+    @property
+    def font_family(self):
+        return self._data.get("style", {}).get("fontFamily", "")
+
+    @property
+    def children(self):
+        return [FigmaNode(c, self._design) for c in self._data.get("children", [])]
+
+    @property
+    def raw(self):
+        return self._data
+
+    def find(self, name=None, type=None):
+        for child in self._data.get("children", []):
+            match = (name is None or child.get("name") == name) and \
+                    (type is None or child.get("type") == type)
+            if match:
+                return FigmaNode(child, self._design)
+            result = FigmaNode(child, self._design).find(name=name, type=type)
+            if result is not None:
+                return result
+        return None
+
+    def find_all(self, name=None, type=None):
+        results = []
+        for child in self._data.get("children", []):
+            match = (name is None or child.get("name") == name) and \
+                    (type is None or child.get("type") == type)
+            if match:
+                results.append(FigmaNode(child, self._design))
+            results.extend(FigmaNode(child, self._design).find_all(name=name, type=type))
+        return results
+
+    def to_svg(self, width=None, height=None):
+        return figma_node_to_svg(self._data, width=width, height=height)
+
+    def region_to_svg(self, x, y, w, h):
+        bx, by, _, _ = self.bbox
+        abs_x = bx + x
+        abs_y = by + y
+
+        region_children = []
+        for child in self._data.get("children", []):
+            cb = child.get("absoluteBoundingBox", {})
+            cx, cy = cb.get("x", 0), cb.get("y", 0)
+            cw, ch = cb.get("width", 0), cb.get("height", 0)
+            if cx + cw > abs_x and cx < abs_x + w and \
+               cy + ch > abs_y and cy < abs_y + h:
+                region_children.append(child)
+
+        if not region_children:
+            return None
+
+        synthetic = {
+            "absoluteBoundingBox": {"x": abs_x, "y": abs_y, "width": w, "height": h},
+            "children": region_children,
+        }
+        return figma_node_to_svg(synthetic, width=w, height=h)
+
+
+# -------------------------------------------------------------------------
+# FigmaFrame — with card UI intelligence
+# -------------------------------------------------------------------------
+
+class FigmaFrame(FigmaNode):
+    """A Figma FRAME with methods to detect cards, derive states, and build SVGs."""
+
+    def detect_cards(self, min_size=200, min_radius=10):
+        """Detect card positions by finding large rounded rectangles.
+
+        Returns list of CardRegion sorted left-to-right.
+        """
+        fx, fy = self.bbox[0], self.bbox[1]
+        cards = []
+        for child in self._data.get("children", []):
+            if child.get("type") != "RECTANGLE":
+                continue
+            bbox = child["absoluteBoundingBox"]
+            w, h = bbox["width"], bbox["height"]
+            r = child.get("cornerRadius", 0)
+            if w >= min_size and h >= min_size and r >= min_radius:
+                cards.append(CardRegion(
+                    x=round(bbox["x"] - fx),
+                    y=round(bbox["y"] - fy),
+                    w=round(w),
+                    h=round(h),
+                    bg_color=_get_solid_fill(child),
+                ))
+        cards.sort(key=lambda c: c.x)
+        return cards
+
+    def extract_card_svgs(self, cards):
+        """Extract SVGs for a list of CardRegion."""
+        return [self.region_to_svg(c.x, c.y, c.w, c.h) for c in cards]
+
+    def icon_colors_in_region(self, card):
+        """Collect non-background fill and stroke colors within a card region.
+
+        These are the icon/decoration colors that change on hover.
+        """
+        fx, fy = self.bbox[0], self.bbox[1]
+        abs_cx, abs_cy = fx + card.x, fy + card.y
+        colors = set()
+
+        for child in self._data.get("children", []):
+            bbox = child.get("absoluteBoundingBox", {})
+            bx, by = bbox.get("x", 0), bbox.get("y", 0)
+            bw, bh = bbox.get("width", 0), bbox.get("height", 0)
+            if not (bx + bw > abs_cx and bx < abs_cx + card.w and
+                    by + bh > abs_cy and by < abs_cy + card.h):
+                continue
+            if child.get("type") == "TEXT":
+                continue
+            fill = _get_solid_fill(child)
+            if fill and fill != card.bg_color:
+                colors.add(fill)
+            stroke = _get_solid_stroke(child)
+            if stroke:
+                colors.add(stroke)
+        return list(colors)
+
+    def derive_hover_color(self, hover_frame):
+        """Compare this frame's elements with a hover frame to find the replacement color.
+
+        Returns the color that icons change to on hover.
+        """
+        fx, fy = self.bbox[0], self.bbox[1]
+        hfx, hfy = hover_frame.bbox[0], hover_frame.bbox[1]
+
+        d_fills = {}
+        for c in self._data.get("children", []):
+            if c.get("type") == "BOOLEAN_OPERATION":
+                bbox = c["absoluteBoundingBox"]
+                key = (round(bbox["x"] - fx), round(bbox["y"] - fy))
+                d_fills[key] = _get_solid_fill(c)
+
+        for c in hover_frame.raw.get("children", []):
+            if c.get("type") == "BOOLEAN_OPERATION":
+                bbox = c["absoluteBoundingBox"]
+                key = (round(bbox["x"] - hfx), round(bbox["y"] - hfy))
+                hf = _get_solid_fill(c)
+                df = d_fills.get(key)
+                if df and hf and df != hf:
+                    return hf
+        return None
+
+    def make_hover_svg(self, card, hover_color, icon_colors=None):
+        """Build a hover-state SVG for a card by replacing icon colors.
+
+        Args:
+            card: CardRegion
+            hover_color: The color icons change to on hover.
+            icon_colors: List of colors to replace. If None, auto-detected.
+        """
+        svg = self.region_to_svg(card.x, card.y, card.w, card.h)
+        if not svg:
+            return None
+        if icon_colors is None:
+            icon_colors = self.icon_colors_in_region(card)
+        for color in icon_colors:
+            svg = svg.replace(f'fill="{color}"', f'fill="{hover_color}"')
+            svg = svg.replace(f'stroke="{color}"', f'stroke="{hover_color}"')
+        return svg
+
+    def detect_panel(self, cards):
+        """Detect the description panel from a selected-state frame.
+
+        Looks for elements below the card row (large rounded rect + text).
+        Returns a PanelSpec.
+        """
+        if not cards:
+            return PanelSpec()
+
+        fx, fy = self.bbox[0], self.bbox[1]
+        card_bottom = cards[0].y + cards[0].h  # all cards at same y
+
+        spec = PanelSpec()
+
+        for child in self._data.get("children", []):
+            bbox = child["absoluteBoundingBox"]
+            ry = round(bbox["y"] - fy)
+            if ry <= card_bottom:
+                continue
+
+            if child.get("type") == "RECTANGLE":
+                spec.width = bbox["width"]
+                spec.height = bbox["height"]
+                spec.corner_radius = child.get("cornerRadius", 0)
+                spec.fill = _get_solid_fill(child) or spec.fill
+                spec.stroke = _get_solid_stroke(child) or spec.stroke
+                spec.stroke_width = child.get("strokeWeight", 2)
+                spec.gap = ry - card_bottom
+                panel_x = round(bbox["x"] - fx)
+                panel_y = ry
+
+            elif child.get("type") == "TEXT":
+                style = child.get("style", {})
+                spec.text_fill = _get_solid_fill(child) or spec.text_fill
+                spec.text_size = style.get("fontSize", spec.text_size)
+                text_x = round(bbox["x"] - fx)
+                text_y = round(bbox["y"] - fy)
+                if "panel_x" in dir() and "panel_y" in dir():
+                    spec.text_offset_x = text_x - panel_x
+                    spec.text_offset_y = text_y - panel_y
+
+        return spec
+
+    def extract_selected_svg(self, selected_frame, card, panel):
+        """Extract a selected-state SVG from a selected frame.
+
+        Extracts a taller region that includes the card and the panel
+        below it, directly from the selected frame's elements.
+
+        Args:
+            selected_frame: The FigmaFrame for the selected state.
+            card: CardRegion of the card to extract.
+            panel: PanelSpec from detect_panel().
+
+        Returns:
+            SVG string with viewBox matching the card+panel region.
+        """
+        total_h = card.h + panel.gap + int(panel.height)
+        return selected_frame.region_to_svg(card.x, card.y, card.w, total_h)
+
+
+# -------------------------------------------------------------------------
+# FigmaPage / FigmaSection
+# -------------------------------------------------------------------------
+
+class FigmaPage(FigmaNode):
+
+    def section(self, name):
+        for child in self._data.get("children", []):
+            if child.get("name") == name and child.get("type") == "SECTION":
+                return FigmaSection(child, self._design)
+        return None
+
+    def frame(self, name, section=None):
+        if section:
+            sec = self.section(section)
+            return sec.frame(name) if sec else None
+        for child in self._data.get("children", []):
+            if child.get("name") == name and child.get("type") == "FRAME":
+                return FigmaFrame(child, self._design)
+        return None
+
+
+class FigmaSection(FigmaNode):
+
+    def frame(self, name):
+        for child in self._data.get("children", []):
+            if child.get("name") == name and child.get("type") == "FRAME":
+                return FigmaFrame(child, self._design)
+        return None
+
+    @property
+    def frames(self):
+        return [
+            FigmaFrame(c, self._design)
+            for c in self._data.get("children", [])
+            if c.get("type") == "FRAME"
+        ]
+
+
+# -------------------------------------------------------------------------
+# FigmaDesign
+# -------------------------------------------------------------------------
+
+class FigmaDesign:
+    """Top-level container for a Figma REST API JSON export."""
+
+    def __init__(self, path):
+        self._path = Path(path)
+        with open(self._path) as f:
+            self._data = json.load(f)
+        self._pages = self._extract_pages()
+
+    def _extract_pages(self):
+        doc = self._data.get("document")
+        if doc and "children" in doc:
+            return doc["children"]
+
+        nodes = self._data.get("nodes")
+        if nodes:
+            pages = []
+            for node_id, node_data in nodes.items():
+                node_doc = node_data.get("document", {})
+                node_type = node_doc.get("type", "")
+                if node_type == "CANVAS":
+                    pages.append(node_doc)
+                elif node_type == "SECTION":
+                    pages.append({
+                        "name": node_doc.get("name", ""),
+                        "type": "CANVAS",
+                        "children": [node_doc],
+                    })
+                elif node_type == "FRAME":
+                    pages.append({
+                        "name": node_doc.get("name", ""),
+                        "type": "CANVAS",
+                        "children": [{
+                            "name": node_doc.get("name", ""),
+                            "type": "SECTION",
+                            "children": [node_doc],
+                        }],
+                    })
+                else:
+                    pages.append(node_doc)
+            return pages
+        return []
+
+    @property
+    def name(self):
+        return self._data.get("name", "")
+
+    @property
+    def pages(self):
+        return [FigmaPage(c, self) for c in self._pages]
+
+    def page(self, name):
+        for child in self._pages:
+            if child.get("name") == name:
+                return FigmaPage(child, self)
+        return None
+
+    def page_by_index(self, index):
+        if 0 <= index < len(self._pages):
+            return FigmaPage(self._pages[index], self)
+        return None

--- a/obt.project/scripts/ork/ui/figma/shapes.py
+++ b/obt.project/scripts/ork/ui/figma/shapes.py
@@ -1,0 +1,62 @@
+"""
+Parameterized SVG shape primitives for Figma-style UI.
+
+All functions return SVG markup fragments (not complete documents).
+Colors, positions, and scale are caller-supplied.
+"""
+
+
+def person_silhouette_svg(color, cx=0, cy=0, scale=1.0):
+    """SVG group for a single person silhouette (57x71 base units).
+
+    Head (circle), shoulder bar, and two overlapping body rectangles.
+
+    Args:
+        color: Fill color (e.g. "#166714")
+        cx, cy: Center position in parent coordinate space
+        scale: Scale factor (1.0 = 57x71 units)
+    """
+    ox = cx - 28.5 * scale
+    oy = cy - 35.5 * scale
+    s = scale
+    return (
+        f'<g transform="translate({ox},{oy}) scale({s})">'
+        f'<ellipse cx="28.5" cy="14.5" rx="14.5" ry="14.5" fill="{color}"/>'
+        f'<rect x="0" y="27" width="57" height="12" rx="2" fill="{color}"/>'
+        f'<rect x="7" y="22" width="28" height="50" rx="2" fill="{color}"/>'
+        f'<rect x="22" y="22" width="28" height="50" rx="2" fill="{color}"/>'
+        f'</g>'
+    )
+
+
+def multi_person_svg(color, cx=0, cy=0, scale=1.0, count=3, positions=None):
+    """SVG for multiple person silhouettes at specified positions.
+
+    Args:
+        color: Fill color for all silhouettes.
+        cx, cy: Center of the group in parent coordinate space.
+        scale: Scale factor applied to positions and silhouettes.
+        count: Number of persons (capped to len(positions)).
+        positions: List of (dx, dy) offsets from (cx, cy) at scale=1.
+                   If None, uses a default triangle layout.
+    """
+    if positions is None:
+        positions = [
+            (-44.5, 36.5),
+            (45.5,  36.5),
+            (0.5,  -35.0),
+        ]
+    parts = []
+    for dx, dy in positions[:count]:
+        parts.append(person_silhouette_svg(
+            color,
+            cx=cx + dx * scale,
+            cy=cy + dy * scale,
+            scale=scale,
+        ))
+    return "\n".join(parts)
+
+
+def circle_icon_svg(color, cx=0, cy=0, r=14.5):
+    """Simple filled circle."""
+    return f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="{color}"/>'

--- a/obt.project/scripts/ork/ui/icon_library.py
+++ b/obt.project/scripts/ork/ui/icon_library.py
@@ -48,6 +48,34 @@ def text_icon(text, width=24, height=24, font_size=12, color="#E6E6E6"):
 
 ################################################################################
 
+def from_svg_string_auto(svg_string, width):
+  """
+  Render an SVG string to an RGBA image, preserving aspect ratio.
+  Width is fixed; height is derived from the SVG viewBox.
+  Falls back to square if viewBox is absent or square.
+
+  Args:
+    svg_string: SVG markup as a string
+    width: Output width in pixels
+
+  Returns:
+    lev2.Image (image_ptr_t)
+  """
+  height = width  # default: square
+  vb_start = svg_string.find('viewBox="')
+  if vb_start >= 0:
+    vb_start += len('viewBox="')
+    vb_end = svg_string.find('"', vb_start)
+    parts = svg_string[vb_start:vb_end].split()
+    if len(parts) == 4:
+      vb_w = float(parts[2])
+      vb_h = float(parts[3])
+      if vb_w > 0:
+        height = int(width * vb_h / vb_w)
+  return from_svg_string(svg_string, width, height)
+
+################################################################################
+
 def from_svg_string(svg_string, width, height):
   """
   Render an SVG string to an RGBA image.

--- a/ork.lev2/inc/ork/lev2/ui/filesystem_view.h
+++ b/ork.lev2/inc/ork/lev2/ui/filesystem_view.h
@@ -150,6 +150,8 @@ struct FilesystemView : public Group {
   std::function<void(const std::string& path)> _onDelete;
   std::function<void(const std::string& old_path, const std::string& new_name)> _onRename;
   std::function<void(const std::string& path, int screen_x, int screen_y)> _onContextMenu;
+  std::function<void(const std::string& path)> _onHover;
+
 
   //////////////////////////////////////////////////////////////
   // Appearance - List mode
@@ -177,6 +179,8 @@ struct FilesystemView : public Group {
   int _icon_size = 64;
   int _icon_spacing = 8;
   int _icon_label_height = 32;
+  bool _icon_center_h = false;  // center icon grid horizontally
+  bool _icon_center_v = false;  // center icon grid vertically
 
   //////////////////////////////////////////////////////////////
   // Appearance - Common
@@ -212,6 +216,7 @@ struct FilesystemView : public Group {
   void _updateIconCache(lev2::Context* ctx, const std::string& path, int size);
   lev2::texture_ptr_t _getIconForPath(lev2::Context* ctx, const std::string& path, FileType type, int size);
   void clearIconCache() { _icon_cache.clear(); _folder_icon_texture = nullptr; _file_icon_texture = nullptr; }
+  void clearIconCacheForPath(const std::string& path) { _icon_cache.erase(path); }
 
   //////////////////////////////////////////////////////////////
   // Composition (sub-widgets)

--- a/ork.lev2/pyext/src/pyext_ui_filesystem.cpp
+++ b/ork.lev2/pyext/src/pyext_ui_filesystem.cpp
@@ -753,6 +753,14 @@ void pyinit_ui_filesystem(py::module& uimodule) {
                   callback(path, x, y);
                 };
               })
+          .def(
+              "onHover",
+              [](ui::filesystem_view_ptr_t view, py::object callback) { //
+                view->_onHover = [callback](const std::string& path) {
+                  py::gil_scoped_acquire acquire;
+                  callback(path);
+                };
+              })
           // Appearance - List mode
           .def_readwrite("item_height", &ui::FilesystemView::_item_height)
           .def_readwrite("icon_column_width", &ui::FilesystemView::_icon_column_width)
@@ -771,6 +779,8 @@ void pyinit_ui_filesystem(py::module& uimodule) {
           .def_readwrite("icon_size", &ui::FilesystemView::_icon_size)
           .def_readwrite("icon_spacing", &ui::FilesystemView::_icon_spacing)
           .def_readwrite("icon_label_height", &ui::FilesystemView::_icon_label_height)
+          .def_readwrite("icon_center_h", &ui::FilesystemView::_icon_center_h)
+          .def_readwrite("icon_center_v", &ui::FilesystemView::_icon_center_v)
           .def_readwrite("icon_anim_fps", &ui::FilesystemView::_icon_anim_fps)
           // Appearance - Common
           .def_property(
@@ -868,6 +878,9 @@ void pyinit_ui_filesystem(py::module& uimodule) {
               "Default file icon image (converted to texture lazily)")
           .def("clearIconCache", &ui::FilesystemView::clearIconCache,
               "Clear the icon cache (useful after directory change)")
+          .def("clearIconCacheForPath", &ui::FilesystemView::clearIconCacheForPath,
+              py::arg("path"),
+              "Clear cached icon for a specific path only")
           .def(
               "addToolbar",
               [](ui::filesystem_view_ptr_t view, const std::string& name, int height) -> ui::toolbar_ptr_t {

--- a/ork.lev2/src/ui/widgets/filesystem_view.cpp
+++ b/ork.lev2/src/ui/widgets/filesystem_view.cpp
@@ -499,8 +499,11 @@ HandlerResult ContentWidget::DoOnUiEvent(event_constptr_t ev) {
 
     case EventCode::MOVE: {
       std::string hovered_path = _fsview->_getItemPathAt(localX, localY);
-      if (!hovered_path.empty() && _fsview->_hovered_path != hovered_path) {
+      if (_fsview->_hovered_path != hovered_path) {
         _fsview->_hovered_path = hovered_path;
+        if (_fsview->_onHover) {
+          _fsview->_onHover(hovered_path);
+        }
       }
       break;
     }
@@ -898,9 +901,15 @@ int FilesystemView::_getItemIndexAt(int local_x, int local_y) const {
     int cell_width = _icon_size + _icon_spacing;
     int cell_height = _icon_size + _icon_label_height + _icon_spacing;
     int cols = std::max(1, available_width / cell_width);
-    int col = (local_x - _icon_spacing) / cell_width;
-    int row = content_y / cell_height;
-    if (col >= 0 && col < cols) {
+    int rows = ((int)_visible_items.size() + cols - 1) / cols;
+    int items_in_first_row = std::min((int)_visible_items.size(), cols);
+    int grid_width = items_in_first_row * cell_width - _icon_spacing;
+    int grid_height = rows * cell_height;
+    int x_offset = _icon_center_h ? std::max(0, (_geometry._w - grid_width) / 2) : _icon_spacing;
+    int y_offset = _icon_center_v ? std::max(0, ((_content_widget ? _content_widget->height() : _geometry._h) - grid_height) / 2) : 0;
+    int col = (local_x - x_offset) / cell_width;
+    int row = (content_y - y_offset) / cell_height;
+    if (col >= 0 && col < cols && row >= 0) {
       int index = row * cols + col;
       if (index >= 0 && index < (int)_visible_items.size()) return index;
     }
@@ -1135,13 +1144,21 @@ void FilesystemView::_drawContentIconMode(drawevent_constptr_t drwev) {
     int cell_width = _icon_size + _icon_spacing;
     int cell_height = _icon_size + _icon_label_height + _icon_spacing;
     int cols = std::max(1, available_width / cell_width);
+    int rows = ((int)_visible_items.size() + cols - 1) / cols;
+
+    // Centering offsets
+    int items_in_first_row = std::min((int)_visible_items.size(), cols);
+    int grid_width = items_in_first_row * cell_width - _icon_spacing;
+    int grid_height = rows * cell_height;
+    int x_offset = _icon_center_h ? std::max(0, (_geometry._w - grid_width) / 2) : _icon_spacing;
+    int y_offset = _icon_center_v ? std::max(0, (_content_widget->height() - grid_height) / 2) : 0;
 
     for (size_t i = 0; i < _visible_items.size(); i++) {
       int col = i % cols;
       int row = i / cols;
 
-      int item_x = ix1 + _icon_spacing + col * cell_width;
-      int item_y = iy1 - _scroll_offset + row * cell_height;
+      int item_x = ix1 + x_offset + col * cell_width;
+      int item_y = iy1 + y_offset - _scroll_offset + row * cell_height;
 
       if (item_y + cell_height < iy1) continue;
       if (item_y > iy2) break;
@@ -1359,9 +1376,19 @@ void FilesystemView::_drawIconItem(drawevent_constptr_t drwev, const VisibleItem
       fxi->pushRasterState(rs);
       tgt->PushModColor(fvec4(1, 1, 1, 1));
       _tex_material->SetTexture(lev2::ETEXDEST_DIFFUSE, icon_texture.get());
+
+      // Respect texture aspect ratio: tall textures extend below the icon cell
+      int icon_w = _icon_size - 8;
+      int icon_h = icon_w;
+      int tex_w = icon_texture->_width;
+      int tex_h = icon_texture->_height;
+      if (tex_w > 0 && tex_h > tex_w) {
+        icon_h = icon_w * tex_h / tex_w;
+      }
+
       primi->RenderQuadAtZ(_tex_material.get(),
-                           x_pos + 4, x_pos + _icon_size - 4,
-                           y_pos + 4, y_pos + _icon_size - 4,
+                           x_pos + 4, x_pos + 4 + icon_w,
+                           y_pos + 4, y_pos + 4 + icon_h,
                            0.0f, 0.0f, 1.0f, 0.0f, 1.0f);
       tgt->PopModColor();
       fxi->popRasterState();


### PR DESCRIPTION
## Summary
- Deterministic Figma REST API JSON → SVG converter handling all node types (RECTANGLE, VECTOR, ELLIPSE, TEXT, BOOLEAN_OPERATION, FRAME, GROUP, INSTANCE)
- `fillGeometry` SVG paths for pixel-perfect shapes (requires `geometry=paths` API param)
- Inside-stroke rendering via SVG stroke+clip on fillGeometry
- Boolean union via fillGeometry or clipPath fallback
- `FigmaDesign` class: load JSON, navigate pages/sections/frames, find elements
- Card UI intelligence: `detect_cards`, `derive_hover_color`, `make_hover_svg`, `detect_panel`, `extract_selected_svg`, `region_to_svg`

> **Note:** This builds on #218. Merge #218 first, then rebase this PR — the diff will reduce to only the `ork/ui/figma/` module.

## Test plan
- [ ] Merge #218 first, then rebase this branch
- [ ] Fetch Figma JSON with `geometry=paths`
- [ ] Run test runner. Cards render from Figma design with hover/select states