### PR TITLE
Add RunningStats. Improve TimePrediction. 

### DIFF
--- a/ork.core/inc/ork/kernel/timer.h
+++ b/ork.core/inc/ork/kernel/timer.h
@@ -115,42 +115,6 @@ struct AdaptiveWait {
 using adaptive_wait_ptr_t = std::shared_ptr<AdaptiveWait>;
 
 ///////////////////////////////////////////////////////////////////////////////
-// TimePredictor
-//   Tracks a recurring event and predicts when it will next occur.
-//   Call markPredictionTarget() each time the event happens.
-//   Call predictNextTarget() at any time to get the predicted epoch ms.
-///////////////////////////////////////////////////////////////////////////////
-
-struct TimePredictor {
-
-  static constexpr size_t HISTORY_SIZE = 16;
-
-  // Record that the tracked event just occurred at the given epoch ms.
-  // Updates the rolling average interval between occurrences.
-  void markPredictionTarget(double epoch_ms);
-
-  // Convenience overload — uses Timer::getEpochMS() as the timestamp.
-  void markPredictionTarget();
-
-  // Predicted absolute epoch milliseconds of the next occurrence.
-  // Returns 0 until 2 marks have been recorded.
-  double predictNextTarget() const;
-
-  double avgIntervalMS() const { return _avg_interval_ms; }
-  double stddevMS() const      { return _stddev_ms; }
-
-  double _last_mark_ms    = 0.0;
-  double _avg_interval_ms = 0.0;
-  double _stddev_ms       = 0.0;
-  double _history[HISTORY_SIZE] = {};
-  size_t _history_index   = 0;
-  size_t _history_count   = 0;
-  double _last_prediction = 0.0;
-};
-
-using time_predictor_ptr_t = std::shared_ptr<TimePredictor>;
-
-///////////////////////////////////////////////////////////////////////////////
 // RunningStats
 //   Feed samples one at a time with the poll functions
 //   to calculate min, mac, mean, and stddev.
@@ -191,6 +155,43 @@ struct RunningStats {
 };
 
 using running_stats_ptr_t = std::shared_ptr<RunningStats>;
+
+///////////////////////////////////////////////////////////////////////////////
+// TimePredictor
+//   Tracks a recurring event and predicts when it will next occur.
+//   Call markPredictionTarget() each time the event happens.
+//   Call predictNextTarget() at any time to get the predicted epoch ms.
+///////////////////////////////////////////////////////////////////////////////
+
+struct TimePredictor {
+
+  static constexpr size_t HISTORY_SIZE = 16;
+
+  // Record that the tracked event just occurred at the given epoch ms.
+  // Updates the rolling average interval between occurrences.
+  void markPredictionTarget(double epoch_ms);
+
+  // Convenience overload — uses Timer::getEpochMS() as the timestamp.
+  void markPredictionTarget();
+
+  // Predicted absolute epoch milliseconds of the next occurrence.
+  // Returns 0 until 2 marks have been recorded.
+  double predictNextTarget() const;
+
+  double avgIntervalMS() const { return _avg_interval_ms; }
+  double stddevMS() const      { return _stddev_ms; }
+
+  double _last_mark_ms    = 0.0;
+  double _avg_interval_ms = 0.0;
+  double _stddev_ms       = 0.0;
+  double _history[HISTORY_SIZE] = {};
+  size_t _history_index   = 0;
+  size_t _history_count   = 0;
+  double _last_prediction = 0.0;
+  RunningStats _epoch_ms_stats;
+};
+
+using time_predictor_ptr_t = std::shared_ptr<TimePredictor>;
 
 ///////////////////////////////////////////////////////////////////////////////
 } // namespace ork

--- a/ork.core/inc/ork/kernel/timer.h
+++ b/ork.core/inc/ork/kernel/timer.h
@@ -31,6 +31,8 @@ static constexpr u64    NS_PER_MS  = 1000000ULL;     // nanoseconds per millisec
 static constexpr u64    NS_PER_SEC = 1000000000ULL;  // nanoseconds per second
 static constexpr double MS_PER_NS  = 1e-6;           // milliseconds per nanosecond (tick)
 static constexpr double SEC_PER_NS = 1e-9;           // seconds per nanosecond (tick)
+static constexpr double SEC_PER_MS = 1e-3;           // seconds per millisecond
+static constexpr double MS_PER_SEC = 1e3;            // milliseconds pers seconds 
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -50,6 +52,9 @@ struct Timer {
 
   // Must be called before use of get_sync_time
   static void   staticInit();
+
+  // Milliseconds since Unix epoch as double (sub-millisecond precision).
+  static double getEpochMS();
 
   // Seconds since staticInit() was called.
   static double get_sync_time();
@@ -111,36 +116,81 @@ using adaptive_wait_ptr_t = std::shared_ptr<AdaptiveWait>;
 
 ///////////////////////////////////////////////////////////////////////////////
 // TimePredictor
-//
-// Tracks a recurring event and predicts when it will next occur.
-// Call markPredictionTarget() each time the event happens.
-// Call predictNextTarget() at any time to get the predicted absolute tick
-// of the next occurrence, based on a rolling average of observed intervals.
+//   Tracks a recurring event and predicts when it will next occur.
+//   Call markPredictionTarget() each time the event happens.
+//   Call predictNextTarget() at any time to get the predicted epoch ms.
 ///////////////////////////////////////////////////////////////////////////////
 
 struct TimePredictor {
 
   static constexpr size_t HISTORY_SIZE = 16;
 
-  // Record that the tracked event just occurred.
+  // Record that the tracked event just occurred at the given epoch ms.
   // Updates the rolling average interval between occurrences.
+  void markPredictionTarget(double epoch_ms);
+
+  // Convenience overload — uses Timer::getEpochMS() as the timestamp.
   void markPredictionTarget();
 
-  // Predicted absolute system tick of the next occurrence.
-  // Returns last_mark + avg_interval, or 0 until 2 marks have been recorded.
-  u64 predictNextTarget() const;
+  // Predicted absolute epoch milliseconds of the next occurrence.
+  // Returns 0 until 2 marks have been recorded.
+  double predictNextTarget() const;
 
-  u64 avgIntervalNs() const { return _avg_interval_ns; }
+  double avgIntervalMS() const { return _avg_interval_ms; }
+  double stddevMS() const      { return _stddev_ms; }
 
-  u64    _last_mark_tick  = 0;
-  u64    _last_prediction = 0;
-  u64    _avg_interval_ns = 0;
-  u64    _history[HISTORY_SIZE] = {};
+  double _last_mark_ms    = 0.0;
+  double _avg_interval_ms = 0.0;
+  double _stddev_ms       = 0.0;
+  double _history[HISTORY_SIZE] = {};
   size_t _history_index   = 0;
   size_t _history_count   = 0;
+  double _last_prediction = 0.0;
 };
 
 using time_predictor_ptr_t = std::shared_ptr<TimePredictor>;
+
+///////////////////////////////////////////////////////////////////////////////
+// RunningStats
+//   Feed samples one at a time with the poll functions
+//   to calculate min, mac, mean, and stddev.
+///////////////////////////////////////////////////////////////////////////////
+
+struct RunningStats {
+
+  // Feed a new sample. Updates all stats immediately.
+  void pollValue(double sample);
+
+  // Record a call timestamp via getSystemTick() and feed the computed Hz into pollValue.
+  // Call this once per event (e.g. each pose frame) to track event rate.
+  void pollHz();
+
+  // Reset to initial state.
+  void reset();
+
+  // sample stddev — returns 0 until 2+ samples
+  double stddev() const;
+
+  // upper end of the distribution: mean + sqrt(3) * stddev
+  // for a uniform distribution this equals the max of the range
+  double upperRange() const { return _mean + sqrt(3.0) * stddev(); }
+
+  void printStats(const char* label = "") const {
+    printf("[RunningStats] %s last:%.4f count:%lld min:%.4f max:%.4f mean:%.4f stddev:%.4f\n",
+           label, _last_value, _count, _min, _max, _mean, stddev());
+  }
+
+  double  _min        =  1e300;
+  double  _max        = -1e300;
+  double  _mean       =  0.0;
+  double  _m2         =  0.0;
+  double  _last_value =  0.0;
+  int64_t _count      =  0;
+  int64_t _warmup     =  10;   // samples to discard before accumulating stats
+  u64     _last_tick  =  0;
+};
+
+using running_stats_ptr_t = std::shared_ptr<RunningStats>;
 
 ///////////////////////////////////////////////////////////////////////////////
 } // namespace ork

--- a/ork.core/src/kernel/timer.cpp
+++ b/ork.core/src/kernel/timer.cpp
@@ -284,12 +284,15 @@ void TimePredictor::markPredictionTarget(double epoch_ms) {
   // TODO this is WIP. Expiriments need to be done to figure out what is best.
   // Right now it seems rolling recent history is better than RunningStats
   // which takes into account infinite time.
-
   // epoch_ms is expected target
   if (_last_mark_ms > 0.0) {
 
     // store interal since last
     double interval = epoch_ms - _last_mark_ms;
+    // _epoch_ms_stats.pollValue(interval);
+    // _epoch_ms_stats.printStats("prediction target delta");
+    // [RunningStats] prediction target delta last:11.1116 count:8032 min:11.1111 max:11.1118 mean:11.1115 stddev:0.0001
+
     _history[_history_index] = interval;
     _history_index = (_history_index + 1) % HISTORY_SIZE;
     if (_history_count < HISTORY_SIZE)

--- a/ork.core/src/kernel/timer.cpp
+++ b/ork.core/src/kernel/timer.cpp
@@ -54,6 +54,12 @@ Timer::~Timer() {
   delete _thread;
 }
 
+double Timer::getEpochMS() {
+  timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  return double(ts.tv_sec) * 1e3 + double(ts.tv_nsec) * 1e-6;
+}
+
 void Timer::Start() {
   _start_time = get_sync_time();
 }
@@ -274,36 +280,100 @@ void usleep(int microsec) {
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 
-///////////////////////////////////////////////////////////////////////////////
+void TimePredictor::markPredictionTarget(double epoch_ms) {
+  // TODO this is WIP. Expiriments need to be done to figure out what is best.
+  // Right now it seems rolling recent history is better than RunningStats
+  // which takes into account infinite time.
 
-void TimePredictor::markPredictionTarget() {
-  u64 now = Timer::getSystemTick();
-  if (_last_mark_tick > 0) {
-    // Log prediction error from previous mark's prediction
-    if (0) {
-      int64_t error_ns = (int64_t)now - (int64_t)_last_prediction;
-      logchan_timer->log("predict error: %+.3f us  avg_interval: %.3f ms",
-                         double(error_ns) * 1e-3,
-                         double(_avg_interval_ns) * 1e-6);
-    }
-    u64 interval = now - _last_mark_tick;
+  // epoch_ms is expected target
+  if (_last_mark_ms > 0.0) {
+
+    // store interal since last
+    double interval = epoch_ms - _last_mark_ms;
     _history[_history_index] = interval;
     _history_index = (_history_index + 1) % HISTORY_SIZE;
     if (_history_count < HISTORY_SIZE)
       _history_count++;
-    u64 sum = 0;
+
+    // rolling average of intervals
+    double sum = 0.0;
     for (size_t i = 0; i < _history_count; i++)
       sum += _history[i];
-    _avg_interval_ns = sum / _history_count;
+    _avg_interval_ms = sum / double(_history_count);
+
+    // stddev over history to bias prediction toward later edge of jitter window
+    if (_history_count > 1) {
+      double m2 = 0.0;
+      for (size_t i = 0; i < _history_count; i++) {
+        double d = _history[i] - _avg_interval_ms;
+        m2 += d * d;
+      }
+      _stddev_ms = sqrt(m2 / double(_history_count - 1));
+    }
   }
-  _last_mark_tick   = now;
-  _last_prediction  = predictNextTarget();
+  _last_mark_ms    = epoch_ms;
+  _last_prediction = predictNextTarget();
 }
 
-u64 TimePredictor::predictNextTarget() const {
+void TimePredictor::markPredictionTarget() {
+  markPredictionTarget(Timer::getEpochMS());
+}
+
+double TimePredictor::predictNextTarget() const {
   if (_history_count == 0)
-    return 0;
-  return _last_mark_tick + _avg_interval_ns;
+    return 0.0;
+  
+  // start from last reported scanout, step avg+stddev until past now
+  double interval = _avg_interval_ms + _stddev_ms;
+  double now      = Timer::getEpochMS();
+  double next     = _last_mark_ms;
+  while (next <= now)
+    next += interval;
+
+  return next;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void RunningStats::pollValue(double sample) {
+  _last_value = sample;
+  if (_warmup > 0) {
+    _warmup--;
+    return;
+  }
+  _count++;
+  double delta = sample - _mean;
+  _mean += delta / double(_count);
+  _m2   += delta * (sample - _mean); // Welford's update
+  if (sample < _min) _min = sample;
+  if (sample > _max) _max = sample;
+}
+
+void RunningStats::pollHz() {
+  u64 now = Timer::getSystemTick();
+  if (_last_tick != 0) {
+    u64 delta_ns = now - _last_tick;
+    if (delta_ns > 0) {
+      double hz = double(NS_PER_SEC) / double(delta_ns);
+      pollValue(hz);
+    }
+  }
+  _last_tick = now;
+}
+
+void RunningStats::reset() {
+  _min        =  1e300;
+  _max        = -1e300;
+  _mean       =  0.0;
+  _m2         =  0.0;
+  _last_value =  0.0;
+  _count      =  0;
+  _warmup     =  10;
+  _last_tick  =  0;
+}
+
+double RunningStats::stddev() const {
+  return _count > 1 ? sqrt(_m2 / double(_count - 1)) : 0.0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ork.lev2/inc/ork/lev2/gfx/gfxenv.h
+++ b/ork.lev2/inc/ork/lev2/gfx/gfxenv.h
@@ -477,6 +477,8 @@ public:
   Timer _ctxtimer;
 
   time_predictor_ptr_t _render_timing_estimator = std::make_shared<TimePredictor>();
+  RunningStats _submit_delta_stats;
+  double _last_submit_epoch_ms = 0.0;
 
   svar64_t _pyimpl_beforeEndFrame;
 protected:

--- a/ork.lev2/inc/ork/lev2/vr/vr.h
+++ b/ork.lev2/inc/ork/lev2/vr/vr.h
@@ -112,15 +112,20 @@ struct Device {
   virtual void gpuUpdate(RenderContextFrameData& RCFD)              = 0;
   virtual void __composite(Context* targ, Texture* twoeyetex) const = 0;
 
-  // Returns the predicted absolute system tick (Timer::getSystemTick() scale)
+  // Returns the predicted absolute epoch milliseconds (Timer::getEpochMS() scale)
   // when the current frame will finish rendering. Used for pose prediction.
   // Returns 0 if not enough frames have been rendered yet.
-  u64 predictedRenderFinishTick() const;
+  double predictedRenderFinishEpochMS() const;
 
   // Shared with the gfx context producing frames for this device.
-  ork::time_predictor_ptr_t _render_timing_estimator;
+  ork::time_predictor_ptr_t _render_timing_estimator; 
 
   std::map<std::string, fmtx4> _posemap;
+
+  // Posemap is getting updated from the sensor thread and read from the rendering thread.
+  // We need a synchronization primitive for this. TODO should be SPSCQueue
+  mutable std::mutex _posemap_mutex; 
+
   cameramatrices_ptr_t _leftcamera       = nullptr;
   cameramatrices_ptr_t _centercamera     = nullptr;
   cameramatrices_ptr_t _rightcamera      = nullptr;

--- a/ork.lev2/src/gfx/vulkan/headers/vulkan_ctx.h
+++ b/ork.lev2/src/gfx/vulkan/headers/vulkan_ctx.h
@@ -900,6 +900,13 @@ public:
   
   void suspendRenderPass();
   void resumeRenderPass();
+
+#if defined(__APPLE__)
+  void* _displayLink               = nullptr;
+  double _displayLinkEpochOffsetMS = 0.0;
+  void _startDisplayLink();
+  void _stopDisplayLink();
+#endif
 };
 ///////////////////////////////////////////////////////////////////////////
   struct VkCaptureBufferImpl {

--- a/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
@@ -6,6 +6,9 @@
 ////////////////////////////////////////////////////////////////
 
 #include "headers/vulkan_ctx.h"
+#if defined(__APPLE__)
+#include <dispatch/dispatch.h>
+#endif
 #if defined(__linux__)
 #include "headers/vk_swapchain_drm.h"
 #endif
@@ -610,6 +613,9 @@ VkContext::VkContext() {
 ///////////////////////////////////////////////////////
 
 VkContext::~VkContext() {
+#if defined(__APPLE__)
+    _stopDisplayLink();
+#endif
     if (_vkpresentationsurface != VK_NULL_HANDLE && _GVI) {
       printf("VkContext::~VkContext: destroying VkSurface %p\n", (void*)_vkpresentationsurface);
       vkDestroySurfaceKHR(_GVI->_instance, _vkpresentationsurface, nullptr);
@@ -994,6 +1000,15 @@ void VkContext::_onGpuPostInit() {
   _cmdbufcurpri_gfx = nullptr;
 
   //printf("VkContext::_onGpuPostInit: gpuPreInit transitions complete\n");
+
+#if defined(__APPLE__)
+  if (_vkpresentationsurface != VK_NULL_HANDLE) {
+    auto* self = this;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+      self->_startDisplayLink();
+    });
+  }
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1016,6 +1031,15 @@ void VkContext::_doEndFrame() {
 
   // read back GPU timestamps now that the GPU has finished executing
   OrkProfilerFrameEnd(CHANNEL_GPU);
+
+#if defined(__APPLE__)
+  // Apple marks the prediction target from vulkan_displaylink.mm
+  // if the context was created with a surface
+  if (_vkpresentationsurface == VK_NULL_HANDLE)
+    _render_timing_estimator->markPredictionTarget();
+#else
+  _render_timing_estimator->markPredictionTarget();
+#endif
 
   ////////////////////////////////////////
 

--- a/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
@@ -1027,7 +1027,19 @@ void VkContext::_doEndFrame() {
 
   // End and submit primary command buffer. Currently this also waits.
   _doEndPrimaryCommandBuffer();
-  _doSubmitPrimaryCommandBuffer(); 
+  _doSubmitPrimaryCommandBuffer();
+
+  // TODO turn into OrkProfiler macro
+  // {
+  //   double now = Timer::getEpochMS();
+  //   if (_last_submit_epoch_ms > 0.0) {
+  //     double delta = now - _last_submit_epoch_ms;
+  //     _submit_delta_stats.pollValue(delta);
+  //     _submit_delta_stats.printStats("primary cmdbuf submit delta");
+  //   }
+  //   _last_submit_epoch_ms = now;
+  // }
+  // [RunningStats] primary cmdbuf submit delta last:9.8372 count:7538 min:5.2849 max:18.7739 mean:11.1116 stddev:1.2483
 
   // read back GPU timestamps now that the GPU has finished executing
   OrkProfilerFrameEnd(CHANNEL_GPU);

--- a/ork.lev2/src/gfx/vulkan/vulkan_displaylink.mm
+++ b/ork.lev2/src/gfx/vulkan/vulkan_displaylink.mm
@@ -1,8 +1,13 @@
 #if defined(__APPLE__)
+#ifndef GLFW_EXPOSE_NATIVE_COCOA
+#define GLFW_EXPOSE_NATIVE_COCOA
+#endif
 #include "headers/vulkan_ctx.h"
 #include <ork/kernel/timer.h>
 #include <ork/util/logger.h>
+#include <ork/lev2/glfw/ctx_glfw.h>
 #import <CoreVideo/CoreVideo.h>
+#import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 #include <mach/mach_time.h>
 #include <memory>
@@ -11,7 +16,7 @@
 namespace ork::lev2::vulkan {
 ////////////////////////////////////////////////////////////////////////////////
 
-static logchannel_ptr_t logchan_displaylink = logger()->configureChannel("VKDISPLAYLINK", fvec3(0.7, 0.9, 0.7), false);
+static logchannel_ptr_t logchan_displaylink = logger()->configureChannel("VKDISPLAYLINK", fvec3(0.7, 0.9, 0.7), true);
 
 // CVDisplayLink fires once per vblank on its own thread. outputTime->hostTime
 // is the upcoming scanout in Mach absolute time — converted to epoch ms and
@@ -58,15 +63,37 @@ void VkContext::_startDisplayLink() {
         machToNs
     };
 
-    logchan_displaylink->log("starting, epochOffset=%.3f estimator=%p",
-           _displayLinkEpochOffsetMS, (void*)w->estimator.get());
+    // Get the CGDirectDisplayID for whichever display the window is on,
+    // so CVDisplayLink fires at that display's actual refresh rate (e.g. 90Hz)
+    // rather than the lowest-common-denominator of all active displays.
+    CGDirectDisplayID displayID = CGMainDisplayID();
+    auto glfw_container = (CtxGLFW*)mCtxBase;
+    if (glfw_container && glfw_container->_glfwWindow) {
+        NSWindow* nswin = glfwGetCocoaWindow(glfw_container->_glfwWindow);
+        if (nswin) {
+            NSScreen* screen = nswin.screen;
+            if (screen) {
+                NSDictionary* desc = screen.deviceDescription;
+                NSNumber* screenID = desc[@"NSScreenNumber"];
+                if (screenID) {
+                    displayID = (CGDirectDisplayID)screenID.unsignedIntValue;
+                }
+            }
+        }
+    }
 
-    CVDisplayLinkCreateWithActiveCGDisplays(&w->cvLink);
+    logchan_displaylink->log("starting on display=0x%x epochOffset=%.3f estimator=%p",
+           displayID, _displayLinkEpochOffsetMS, (void*)w->estimator.get());
+
+    CVDisplayLinkCreateWithCGDisplay(displayID, &w->cvLink);
     CVDisplayLinkSetOutputCallback(w->cvLink, displayLinkCallback, w);
     CVDisplayLinkStart(w->cvLink);
 
+    CVTime period = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(w->cvLink);
+    double hz = (period.flags & kCVTimeIsIndefinite) ? 0.0
+              : double(period.timeScale) / double(period.timeValue);
+    logchan_displaylink->log("started cvLink=%p display=0x%x refresh=%.2fHz", (void*)w->cvLink, displayID, hz);
     _displayLink = (void*)w;
-    logchan_displaylink->log("started cvLink=%p", (void*)w->cvLink);
 }
 
 void VkContext::_stopDisplayLink() {

--- a/ork.lev2/src/gfx/vulkan/vulkan_displaylink.mm
+++ b/ork.lev2/src/gfx/vulkan/vulkan_displaylink.mm
@@ -1,0 +1,85 @@
+#if defined(__APPLE__)
+#include "headers/vulkan_ctx.h"
+#include <ork/kernel/timer.h>
+#include <ork/util/logger.h>
+#import <CoreVideo/CoreVideo.h>
+#import <Foundation/Foundation.h>
+#include <mach/mach_time.h>
+#include <memory>
+
+////////////////////////////////////////////////////////////////////////////////
+namespace ork::lev2::vulkan {
+////////////////////////////////////////////////////////////////////////////////
+
+static logchannel_ptr_t logchan_displaylink = logger()->configureChannel("VKDISPLAYLINK", fvec3(0.7, 0.9, 0.7), false);
+
+// CVDisplayLink fires once per vblank on its own thread. outputTime->hostTime
+// is the upcoming scanout in Mach absolute time — converted to epoch ms and
+// fed into TimePredictor, giving vblank-accurate scanout prediction.
+
+struct CVDisplayLinkWrapper {
+    CVDisplayLinkRef          cvLink        = nullptr;
+    time_predictor_ptr_t      estimator;
+    double                    epochOffsetMS = 0.0;
+    double                    machToNsScale = 1.0;
+};
+
+static CVReturn displayLinkCallback(CVDisplayLinkRef,
+                                    const CVTimeStamp*,
+                                    const CVTimeStamp* outputTime,
+                                    CVOptionFlags,
+                                    CVOptionFlags*,
+                                    void* ctx) {
+    auto* w = (CVDisplayLinkWrapper*)ctx;
+    double hostTime_ms      = double(outputTime->hostTime) * w->machToNsScale * 1e-6;
+    double scanout_epoch_ms = hostTime_ms + w->epochOffsetMS;
+    w->estimator->markPredictionTarget(scanout_epoch_ms);
+
+    static int tick_count = 0;
+    if (tick_count++ < 5) {
+        logchan_displaylink->log("tick %d scanout_epoch_ms=%.3f avgInterval=%.3fms",
+               tick_count, scanout_epoch_ms, w->estimator->avgIntervalMS());
+    }
+    return kCVReturnSuccess;
+}
+
+void VkContext::_startDisplayLink() {
+    mach_timebase_info_data_t tbinfo;
+    mach_timebase_info(&tbinfo);
+    double machToNs = double(tbinfo.numer) / double(tbinfo.denom);
+
+    double mach_now_ms = double(mach_absolute_time()) * machToNs * 1e-6;
+    _displayLinkEpochOffsetMS = Timer::getEpochMS() - mach_now_ms;
+
+    auto* w = new CVDisplayLinkWrapper{
+        nullptr,
+        _render_timing_estimator,
+        _displayLinkEpochOffsetMS,
+        machToNs
+    };
+
+    logchan_displaylink->log("starting, epochOffset=%.3f estimator=%p",
+           _displayLinkEpochOffsetMS, (void*)w->estimator.get());
+
+    CVDisplayLinkCreateWithActiveCGDisplays(&w->cvLink);
+    CVDisplayLinkSetOutputCallback(w->cvLink, displayLinkCallback, w);
+    CVDisplayLinkStart(w->cvLink);
+
+    _displayLink = (void*)w;
+    logchan_displaylink->log("started cvLink=%p", (void*)w->cvLink);
+}
+
+void VkContext::_stopDisplayLink() {
+    if (_displayLink) {
+        auto* w = (CVDisplayLinkWrapper*)_displayLink;
+        _displayLink = nullptr;
+        CVDisplayLinkStop(w->cvLink);
+        CVDisplayLinkRelease(w->cvLink);
+        delete w;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+} // namespace ork::lev2::vulkan
+////////////////////////////////////////////////////////////////////////////////
+#endif

--- a/ork.lev2/src/gfx/vulkan/vulkan_swapchain.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_swapchain.cpp
@@ -681,7 +681,6 @@ void VkSwapChain::submit(vkcontext_rawptr_t ctxVK) {
   _enqueueFrame(ctxVK);
   _enqueuePresentFrame(ctxVK);
   _waitFrame();
-  ctxVK->_render_timing_estimator->markPredictionTarget();
   _incrementFrame();
   _acquired = false;
 }

--- a/ork.lev2/src/vr/base.cpp
+++ b/ork.lev2/src/vr/base.cpp
@@ -4,6 +4,7 @@
 #include <ork/lev2/vr/vr.h>
 #include <ork/kernel/string/deco.inl>
 #include <ork/profiling.inl>
+#include <thread>
 
 ////////////////////////////////////////////////////////////////////////////////
 namespace ork::lev2::orkidvr {
@@ -60,7 +61,7 @@ Device::~Device() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-u64 Device::predictedRenderFinishTick() const {
+double Device::predictedRenderFinishEpochMS() const {
   OrkAssertI(_render_timing_estimator, "VR device has no render timing estimator — was a gfx context wired up via ezapp onGpuInit?");
   return _render_timing_estimator->predictNextTarget();
 }
@@ -106,9 +107,14 @@ void Device::resetCalibration(){
 
 void Device::_updatePosesCommon() {
   EASY_BLOCK("vr-upc");
-  fmtx4 hmd  = _posemap["hmd"];
-  fmtx4 eyeL = _posemap["eyel"];
-  fmtx4 eyeR = _posemap["eyer"];
+  fmtx4 hmd, eyeL, eyeR;
+  {
+    // _posemap written from pose processor thread; lock on read to avoid data race
+    std::lock_guard<std::mutex> lock(_posemap_mutex);
+    hmd  = _posemap["hmd"];
+    eyeL = _posemap["eyel"];
+    eyeR = _posemap["eyer"];
+  }
 
   fvec3 hmdpos;
   fquat hmdrot;


### PR DESCRIPTION
* Add new struct to Timer to enable easy tracking of median and stddev of a codepath.
* Improve the prediction math of the TimePrediction and also make it go off of epoch milliseconds to be consistent with other APIS.
* Add callback to set the TimePrediction from actual blank on Mac.
* Add mutex for posemap into device so poses can be read from multiple threads.