### PR TITLE
Updates for procedural scenes: geometry, materials, instancing, transparency, point lights

### DIFF
--- a/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
@@ -299,6 +299,7 @@ libblock lib_fwd     //
     vec3 N         = TN * 2.0 - vec3(1, 1, 1);
     bool emissive  = length(TN) < 0.1;
     vec3 normal    = normalize(frg_tbn * N);
+    if (!gl_FrontFacing) normal = -normal;
     return _forward_lightingZ(modcolor, albedo, ambrufmtl, emission, eyepos, normal, emissive) * modcolor;
     //return vec3(uvinvy,0);
   }
@@ -323,6 +324,7 @@ libblock lib_fwd     //
     vec3 N         = TN * 2.0 - vec3(1, 1, 1);
     bool emissive  = false;
     vec3 normal    = normalize(frg_tbn * N);
+    if (!gl_FrontFacing) normal = -normal;
     return _forward_lightingZ(vec3(1), albedo, ambrufmtl, emission, EyePostion, normal, emissive);
   }
 }

--- a/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
@@ -316,13 +316,13 @@ libblock lib_fwd     //
 
   vec3 forward_lighting_ntex(vec3 modcolor) {
     vec2 uvinvy    = abs(frg_uv0.xy);
-    vec3 albedo    = vec3(1,1,1);
+    vec3 albedo    = modcolor;
     vec3 TN        = vec3(0.5,0.5,1);
-    vec3 ambrufmtl = vec3(1,1,1);
+    vec3 ambrufmtl = vec3(1, RoughnessFactor, MetallicFactor);
     vec3 emission  = vec3(0,0,0);
     vec3 N         = TN * 2.0 - vec3(1, 1, 1);
     bool emissive  = false;
     vec3 normal    = normalize(frg_tbn * N);
-    return _forward_lightingZ(modcolor, albedo, ambrufmtl, emission, EyePostion, normal, emissive) * modcolor;
+    return _forward_lightingZ(vec3(1), albedo, ambrufmtl, emission, EyePostion, normal, emissive);
   }
 }

--- a/ork.data/platform_lev2/shaders/fxv2/pbr.fxv2
+++ b/ork.data/platform_lev2/shaders/fxv2/pbr.fxv2
@@ -9,12 +9,12 @@ state_block sb_no_cull : sb_default {
 	CullTest = OFF;
 }
 ///////////////////////////////////////////////////////////////
+// sb_cullcw kept as an alias of sb_default; vertex-color techniques get
+// the same PASS_FRONT cull as everything else.
 state_block sb_cullcw : sb_default {
-	CullTest = PASS_BACK;
 }
 ///////////////////////////////////////////////////////////////
 state_block sb_cullcw_alpha : sb_default {
-	CullTest = PASS_BACK;
 	BlendMode = ALPHA;
 	DepthMask = false;
 }

--- a/ork.data/platform_lev2/shaders/fxv2/pbr.fxv2
+++ b/ork.data/platform_lev2/shaders/fxv2/pbr.fxv2
@@ -76,6 +76,16 @@ technique FWD_CT_NM_RI_IN_MO {
 	vf_pass={vs_forward_instanced,ps_forward_test,sb_default}
 }
 ///////////////////////////////////////////////////////////////
+technique FWD_CV_NM_RI_IN_MO {
+	fxconfig=fxcfg_default;
+	vf_pass={vs_forward_instanced_vc,ps_forward_test_vtxcol,sb_cullcw}
+}
+///////////////////////////////////////////////////////////////
+technique FWD_CV_NM_RI_IN_MO_ALPHA {
+	fxconfig=fxcfg_default;
+	vf_pass={vs_forward_instanced_vc,ps_forward_instanced_vtxcol_alpha,sb_cullcw_alpha}
+}
+///////////////////////////////////////////////////////////////
 technique FWD_CT_NM_SK_NI_MO {
 	fxconfig=fxcfg_default;
 	vf_pass={vs_forward_skinned_mono,ps_forward_test,sb_default}

--- a/ork.data/platform_lev2/shaders/fxv2/pbr.fxv2
+++ b/ork.data/platform_lev2/shaders/fxv2/pbr.fxv2
@@ -13,6 +13,12 @@ state_block sb_cullcw : sb_default {
 	CullTest = PASS_BACK;
 }
 ///////////////////////////////////////////////////////////////
+state_block sb_cullcw_alpha : sb_default {
+	CullTest = PASS_BACK;
+	BlendMode = ALPHA;
+	DepthMask = false;
+}
+///////////////////////////////////////////////////////////////
 technique PIK_RI_NI {
 	fxconfig=fxcfg_default;
 	vf_pass={vs_pick_rigid_simple_mono,ps_pick,sb_default}
@@ -55,9 +61,14 @@ technique FWD_CT_NM_RI_NI_MO {
 	vf_pass={vs_forward_test,ps_forward_test,sb_default}
 }
 ///////////////////////////////////////////////////////////////
-technique FWD_CV_NM_RI_NI_MO { 
+technique FWD_CV_NM_RI_NI_MO {
 	fxconfig=fxcfg_default;
 	vf_pass={vs_forward_test_vtxcol,ps_forward_test_vtxcol,sb_cullcw}
+}
+///////////////////////////////////////////////////////////////
+technique FWD_CV_NM_RI_NI_MO_ALPHA {
+	fxconfig=fxcfg_default;
+	vf_pass={vs_forward_test_vtxcol,ps_forward_test_vtxcol_alpha,sb_cullcw_alpha}
 }
 ///////////////////////////////////////////////////////////////
 technique FWD_CT_NM_RI_IN_MO {

--- a/ork.data/platform_lev2/shaders/fxv2/pbrtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/pbrtools.i2
@@ -423,8 +423,22 @@ fragment_shader ps_forward_test_vtxcol //
     : lib_brdf                  //
     : lib_def                   //
     : lib_fwd
-    : std_forward_all {   
-  out_color = vec4(forward_lighting_ntex(frg_clr.xyz), 1);
+    : std_forward_all {
+  out_color = vec4(forward_lighting_ntex(frg_clr.xyz) * ModColor.rgb, frg_clr.a * ModColor.a);
+}
+//////////////////////////////////////
+fragment_shader ps_forward_test_vtxcol_alpha //
+    : fif_FWDTESTVC             //
+    : lib_math                  //
+    : lib_brdf                  //
+    : lib_def                   //
+    : lib_fwd
+    : std_forward_all {
+  vec3 lit = forward_lighting_ntex(frg_clr.xyz) * ModColor.rgb;
+  float vtx_alpha = frg_clr.a;
+  float lum = dot(lit, vec3(0.2126, 0.7152, 0.0722));
+  float boosted = clamp(vtx_alpha + lum * (1.0 - vtx_alpha), vtx_alpha, 1.0);
+  out_color = vec4(lit, boosted * ModColor.a);
 }
 //////////////////////////////////////
 fragment_shader ps_forward_test //

--- a/ork.data/platform_lev2/shaders/fxv2/pbrtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/pbrtools.i2
@@ -441,6 +441,17 @@ fragment_shader ps_forward_test_vtxcol_alpha //
   out_color = vec4(lit, boosted * ModColor.a);
 }
 //////////////////////////////////////
+fragment_shader ps_forward_instanced_vtxcol_alpha //
+    : fif_FWDTESTVC             //
+    : lib_math                  //
+    : lib_brdf                  //
+    : lib_def                   //
+    : lib_fwd
+    : std_forward_all {
+  vec3 lit = forward_lighting_ntex(frg_clr.xyz);
+  out_color = vec4(lit, frg_clr.a);
+}
+//////////////////////////////////////
 fragment_shader ps_forward_test //
     : fif_FWDTEST             //
     : lib_math                  //
@@ -458,13 +469,19 @@ vertex_shader vs_forward_instanced
   : vif_FWDTEST
   : storage_instancing
   : lib_pbr_vtx_instanced {
-  ////////////////////////////////
-  // fetch instance matrix from SSBO
-  ////////////////////////////////
   mat4 instancemtx = _instance_matrices[gl_InstanceIndex];
   vec4 instanced_pos = instancemtx * position;
   vs_instanced(position, normal, binormal);
-  ////////////////////////////////
+  gl_Position = mvp * instanced_pos;
+}
+///////////////////////////////////////////////////////////////
+vertex_shader vs_forward_instanced_vc
+  : vif_FWDTESTVC
+  : storage_instancing
+  : lib_pbr_vtx_instanced_vc {
+  mat4 instancemtx = _instance_matrices[gl_InstanceIndex];
+  vec4 instanced_pos = instancemtx * position;
+  vs_instanced_vc(position, normal, binormal, vtxcolor);
   gl_Position = mvp * instanced_pos;
 }
 ///////////////////////////////////////////////////////////////

--- a/ork.data/platform_lev2/shaders/fxv2/stdtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/stdtools.i2
@@ -216,3 +216,21 @@ libblock lib_pbr_vtx_instanced : ublk_std_matrices : storage_instancing {
   }
 } // lib_pbr_vtx_instanced
 ///////////////////////////////////////////////////////////////
+libblock lib_pbr_vtx_instanced_vc : ublk_std_matrices : storage_instancing {
+  void vs_instanced_vc(vec4 pos, vec3 nrm, vec3 bin, vec4 vclr) {
+    mat4 instance_matrix = _instance_matrices[gl_InstanceIndex];
+    vec4 instance_color  = _instance_colors[gl_InstanceIndex];
+    mat3 instance_rot = mat3(instance_matrix);
+    vec4 cpos         = mv * (instance_matrix * pos);
+    vec3 wnormal      = normalize(instance_rot * nrm);
+    vec3 wbitangent   = normalize(instance_rot * bin);
+    vec3 wtangent     = cross(wbitangent, wnormal);
+    frg_wpos    = m * (instance_matrix * pos);
+    frg_uv0     = vec2(0, 0);
+    frg_tbn     = mat3(wtangent, wbitangent, wnormal);
+    frg_camz    = wnormal.xyz;
+    frg_camdist = -cpos.z;
+    frg_clr     = vclr * instance_color;
+  }
+} // lib_pbr_vtx_instanced_vc
+///////////////////////////////////////////////////////////////

--- a/ork.lev2/inc/ork/lev2/gfx/fx_pipeline.h
+++ b/ork.lev2/inc/ork/lev2/gfx/fx_pipeline.h
@@ -45,6 +45,7 @@ struct FxPipelinePermutation {
   bool _skinned = false;
   bool _is_picking = false;
   bool _has_vtxcolors = false;
+  bool _is_alpha = false;
   bool _vr_mono = false;
   
   fxtechnique_constptr_t _forced_technique = nullptr;

--- a/ork.lev2/inc/ork/lev2/gfx/material_pbr.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/material_pbr.inl
@@ -313,6 +313,8 @@ public:
   // texcolor
 
   fxtechnique_constptr_t _tek_FWD_CT_NM_RI_IN_MO = nullptr;
+  fxtechnique_constptr_t _tek_FWD_CV_NM_RI_IN_MO = nullptr;
+  fxtechnique_constptr_t _tek_FWD_CV_NM_RI_IN_MO_ALPHA = nullptr;
   fxtechnique_constptr_t _tek_FWD_CT_NM_RI_NI_MO = nullptr;
   fxtechnique_constptr_t _tek_FWD_CV_NM_RI_NI_MO = nullptr;
   fxtechnique_constptr_t _tek_FWD_CV_NM_RI_NI_MO_ALPHA = nullptr;

--- a/ork.lev2/inc/ork/lev2/gfx/material_pbr.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/material_pbr.inl
@@ -315,6 +315,7 @@ public:
   fxtechnique_constptr_t _tek_FWD_CT_NM_RI_IN_MO = nullptr;
   fxtechnique_constptr_t _tek_FWD_CT_NM_RI_NI_MO = nullptr;
   fxtechnique_constptr_t _tek_FWD_CV_NM_RI_NI_MO = nullptr;
+  fxtechnique_constptr_t _tek_FWD_CV_NM_RI_NI_MO_ALPHA = nullptr;
   fxtechnique_constptr_t _tek_FWD_CT_NM_RI_IN_ST = nullptr;
   fxtechnique_constptr_t _tek_FWD_CT_NM_RI_NI_ST = nullptr;
   
@@ -376,6 +377,7 @@ public:
 
   bool _stereoVtex = false;
   bool _doubleSided = false;
+  bool _alphaBlend = false;
   float _alphaCutoff = 0.0f;
   int _alphaMode = 0; // 0=OPAQUE, 1=MASK, 2=BLEND
 

--- a/ork.lev2/inc/ork/lev2/gfx/meshutil/rigid_primitive.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/meshutil/rigid_primitive.inl
@@ -129,6 +129,7 @@ template <typename vtx_t> struct RigidPrimitive : public RigidPrimitiveBase {
 
   void fromClusterizer(const XgmClusterizerStd& cluz, lev2::Context* context);
   void renderEML(lev2::Context* context) const; /// draw with context
+  void renderInstancedEML(lev2::Context* context, size_t instance_count) const; /// draw instanced
 
   void renderUnitOrthoWithMaterial(lev2::Context* context, const SRect& vprect, lev2::GfxMaterial* pmat) const;
 
@@ -656,6 +657,19 @@ template <typename vtx_t> void RigidPrimitive<vtx_t>::renderEML(lev2::Context* c
   }
 }
 ////////////////////////////////////////////////////////////////////////////////
+template <typename vtx_t> void RigidPrimitive<vtx_t>::renderInstancedEML(lev2::Context* context, size_t instance_count) const {
+  auto gbi = context->GBI();
+  for (auto& cluster : _gpuClusters) {
+    for (auto& primgroup : cluster->_primgroups) {
+      gbi->DrawInstancedIndexedPrimitiveEML(
+          *cluster->_vtxbuffer.get(),
+          *primgroup->_idxbuffer.get(),
+          primgroup->_primtype,
+          instance_count);
+    }
+  }
+}
+////////////////////////////////////////////////////////////////////////////////
 template <typename vtx_t>
 void RigidPrimitive<vtx_t>::renderUnitOrthoWithMaterial(lev2::Context* context, const SRect& vprect, lev2::GfxMaterial* pmat)
     const {
@@ -700,5 +714,78 @@ using rigidprim_V12C4T16_ptr_t      = std::shared_ptr<rigidprim_V12C4T16_t>;
 using rigidprim_V12N12T16_ptr_t     = std::shared_ptr<rigidprim_V12N12T16_t>;
 using rigidprim_V12N12B12T8C4_t     = meshutil::RigidPrimitive<lev2::SVtxV12N12B12T8C4>;
 using rigidprim_V12N12B12T8C4_ptr_t = std::shared_ptr<rigidprim_V12N12B12T8C4_t>;
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename vtx_t>
+struct InstancedRigidPrimitiveDrawable final : public lev2::InstancedDrawable {
+
+  InstancedRigidPrimitiveDrawable() = default;
+
+  void bindPrimitive(std::shared_ptr<RigidPrimitive<vtx_t>> prim, lev2::material_ptr_t material) {
+    _primitive = prim;
+    _material = material;
+    _fxcache = material->pipelineCache();
+  }
+
+  void gpuInit(lev2::Context* ctx) const {
+    auto FXI = ctx->FXI();
+    _instanceSSBO = FXI->createStorageBuffer(k_ssbo_total_size);
+  }
+
+  void enqueueToRenderQueue(lev2::drawqueueitem_constptr_t item, lev2::IRenderer* renderer) const override {
+    auto context = renderer->GetTarget();
+    if (!_instanceSSBO) {
+      gpuInit(context);
+    }
+    lev2::CallbackRenderable& renderable = renderer->enqueueCallback();
+    renderable._drawable = nullptr;
+    renderable._pickID = _pickID;
+    renderable._sortkey = _sortkey;
+    renderable._instanced = true;
+    renderable.SetModColor(fcolor4::White());
+    renderable.SetDrawableDataA(GetUserDataA());
+    renderable.SetDrawableDataB(GetUserDataB());
+    bool is_alpha = false;
+    if (auto as_pbr = std::dynamic_pointer_cast<lev2::PBRMaterial>(_material)) {
+      is_alpha = as_pbr->_alphaBlend;
+    }
+    renderable.SetRenderCallback([this, is_alpha](lev2::RenderContextInstData& RCID) {
+      auto context = RCID.context();
+      auto RCFD = RCID.rcfd();
+      auto FXI = context->FXI();
+      OrkAssert(_count <= k_max_instances);
+      auto instances_copy = _idbuf_pool.begin_pull();
+      auto ssbo_mapped = FXI->mapStorageBuffer(_instanceSSBO, 0, k_ssbo_total_size, lev2::BufferMapAccess::WRITE_ONLY);
+      char* base_ptr = (char*)ssbo_mapped->_mappedaddr;
+      memcpy(base_ptr + k_ssbo_offset_matrices, instances_copy->_worldmatrices.data(), _count * 64);
+      memcpy(base_ptr + k_ssbo_offset_colors, instances_copy->_modcolors.data(), _count * 16);
+      memcpy(base_ptr + k_ssbo_offset_pickids, instances_copy->_pickids.data(), _count * 8);
+      ssbo_mapped->unmap();
+      _idbuf_pool.end_pull(instances_copy);
+      lev2::FxPipelinePermutation permu;
+      permu._stereo = false;
+      permu._instanced = true;
+      permu._skinned = false;
+      permu._is_picking = false;
+      permu._has_vtxcolors = true;
+      permu._is_alpha = is_alpha;
+      permu._rendering_model = RCFD->_renderingmodel._modelID;
+      auto pipeline = _fxcache->findPipeline(permu);
+      OrkAssert(pipeline);
+      pipeline->wrappedDrawCall(RCID, [&]() {
+        if (pipeline->_parInstanceBlock) {
+          FXI->bindStorageBuffer(pipeline->_parInstanceBlock, _instanceSSBO);
+        }
+        _primitive->renderInstancedEML(context, _count);
+      });
+      RCID._isInstanced = false;
+    });
+  }
+
+  std::shared_ptr<RigidPrimitive<vtx_t>> _primitive;
+  lev2::material_ptr_t _material;
+  lev2::fxpipelinecache_constptr_t _fxcache;
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 } // namespace ork::meshutil

--- a/ork.lev2/inc/ork/lev2/gfx/meshutil/rigid_primitive.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/meshutil/rigid_primitive.inl
@@ -17,6 +17,7 @@
 #include <ork/lev2/gfx/gfxenv_enum.h>
 #include <ork/lev2/gfx/gfxvtxbuf.h>
 #include <ork/lev2/gfx/gfxmaterial.h>
+#include <ork/lev2/gfx/material_pbr.inl>
 #include <ork/lev2/gfx/gfxmodel.h>
 #include <ork/lev2/gfx/targetinterfaces.h>
 #include <unordered_map>
@@ -179,7 +180,11 @@ template <typename vtx_t> struct RigidPrimitive : public RigidPrimitiveBase {
   //////////////////////////////////////////////////////////////////////////////
   void installInCallbackDrawable(lev2::callback_drawable_wkptr_t drw, lev2::material_ptr_t material){
     OrkAssert(material != nullptr);
-    drw.lock()->SetRenderCallback([this,material](lev2::RenderContextInstData& RCID) { //
+    bool is_alpha = false;
+    if (auto as_pbr = std::dynamic_pointer_cast<lev2::PBRMaterial>(material)) {
+      is_alpha = as_pbr->_alphaBlend;
+    }
+    drw.lock()->SetRenderCallback([this,material,is_alpha](lev2::RenderContextInstData& RCID) { //
       auto context = RCID.context();
       auto RCFD = RCID.rcfd();
       lev2::FxPipelinePermutation permu;
@@ -188,6 +193,7 @@ template <typename vtx_t> struct RigidPrimitive : public RigidPrimitiveBase {
       permu._skinned = false;
       permu._is_picking = false;
       permu._has_vtxcolors = true;
+      permu._is_alpha = is_alpha;
       permu._rendering_model = RCFD->_renderingmodel._modelID;
       auto fxcache = material->pipelineCache();
       auto pipeline = fxcache->findPipeline(permu);

--- a/ork.lev2/pyext/src/pyext_gfx_lighting.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_lighting.cpp
@@ -67,6 +67,22 @@ void pyinit_gfx_lighting(py::module& module_lev2) {
             lightdata->mColor = color;
           })
       .def_property(
+          "intensity",                             //
+          [](lightdata_ptr_t lightdata) -> float { //
+            return lightdata->_intensity;
+          },
+          [](lightdata_ptr_t lightdata, float v) { //
+            lightdata->_intensity = v;
+          })
+      .def_property(
+          "shadowCaster",                          //
+          [](lightdata_ptr_t lightdata) -> bool {  //
+            return lightdata->mbShadowCaster;
+          },
+          [](lightdata_ptr_t lightdata, bool v) {  //
+            lightdata->mbShadowCaster = v;
+          })
+      .def_property(
           "shadowBias",                            //
           [](lightdata_ptr_t lightdata) -> float { //
             return lightdata->mShadowBias;
@@ -84,6 +100,22 @@ void pyinit_gfx_lighting(py::module& module_lev2) {
           });
   py::class_<PointLightData, LightData, pointlightdata_ptr_t>(module_lev2, "PointLightData")
       .def(py::init<>())
+      .def_property(
+          "radius",                                      //
+          [](pointlightdata_ptr_t lightdata) -> float {  //
+            return lightdata->_radius;
+          },
+          [](pointlightdata_ptr_t lightdata, float v) {  //
+            lightdata->_radius = v;
+          })
+      .def_property(
+          "falloff",                                     //
+          [](pointlightdata_ptr_t lightdata) -> float {  //
+            return lightdata->_falloff;
+          },
+          [](pointlightdata_ptr_t lightdata, float v) {  //
+            lightdata->_falloff = v;
+          })
       .def(
           "createNode",                      //
           [](pointlightdata_ptr_t lightdata, //
@@ -114,7 +146,16 @@ void pyinit_gfx_lighting(py::module& module_lev2) {
       .def_property(
           "cookiePath",                                          //
           [](spotlightdata_ptr_t d) -> std::string { return d->_cookiePath.c_str(); },
-          [](spotlightdata_ptr_t d, std::string p) { d->_cookiePath = file::Path(p.c_str()); });
+          [](spotlightdata_ptr_t d, std::string p) { d->_cookiePath = file::Path(p.c_str()); })
+      .def(
+          "createNode",                      //
+          [](spotlightdata_ptr_t lightdata, //
+             std::string named,
+             scenegraph::layer_ptr_t layer) -> scenegraph::lightnode_ptr_t { //
+            auto xfgen = [] -> fmtx4 { return fmtx4(); };
+            auto light = std::make_shared<SpotLight>(xfgen, lightdata.get());
+            return layer->createLightNode(named, light);
+          });
   /////////////////////////////////////////////////////////////////////////////////
   py::class_<Light, light_ptr_t>(module_lev2, "Light")
       .def_property_readonly(
@@ -191,7 +232,13 @@ void pyinit_gfx_lighting(py::module& module_lev2) {
             return light->mViewMatrix;
           });
   /////////////////////////////////////////////////////////////////////////////////
-  py::class_<DynamicPointLight, PointLight, dynamicpointlight_ptr_t>(module_lev2, "DynamicPointLight");
+  py::class_<DynamicPointLight, PointLight, dynamicpointlight_ptr_t>(module_lev2, "DynamicPointLight")
+      .def(py::init<>())
+      .def_property_readonly(
+          "data",
+          [](dynamicpointlight_ptr_t light) -> pointlightdata_ptr_t {
+            return light->_inlineData;
+          });
   /////////////////////////////////////////////////////////////////////////////////
   py::class_<DynamicDirectionalLight, DirectionalLight, dynamicdirectionallight_ptr_t>(module_lev2, "DynamicDirectionalLight");
   /////////////////////////////////////////////////////////////////////////////////

--- a/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
@@ -309,6 +309,10 @@ void pyinit_gfx_pbr(py::module& module_lev2) {
                 m->_doubleSided = p;
               })
           .def_property(
+              "alphaBlend",
+              [](pbrmaterial_ptr_t m) -> bool { return m->_alphaBlend; },
+              [](pbrmaterial_ptr_t m, bool v) { m->_alphaBlend = v; })
+          .def_property(
               "pbrcommon",
               [](pbrmaterial_ptr_t mtl) -> pbr::commonstuff_ptr_t { //
                 return mtl->_commonOverride;

--- a/ork.lev2/pyext/src/pyext_gfx_primitives_rigid.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_primitives_rigid.cpp
@@ -544,6 +544,70 @@ void pyinit_gfx_primitives_rigid(py::module& module_lev2) {
           py::arg("verts"), py::arg("faces"), py::arg("context"), py::arg("primitive_type") = nullptr)
       .def("renderEML", [](meshutil::rigidprim_V12N12B12T8C4_ptr_t prim, ctx_t context) { //
         prim->renderEML(context.get());
-      });
+      })
+      .def(
+          "fromArrays",
+          [](meshutil::rigidprim_V12N12B12T8C4_ptr_t prim,
+             py::buffer positions,   // (N,3) float32
+             py::buffer normals,     // (N,3) float32
+             py::buffer binormals,   // (N,3) float32
+             py::buffer uvs,         // (N,2) float32
+             py::buffer colors,      // (N,4) uint8 RGBA, or empty
+             py::buffer indices,     // (M,) uint32
+             ctx_t context) {
+            auto pos_info = positions.request();
+            auto nrm_info = normals.request();
+            auto bin_info = binormals.request();
+            auto uv_info  = uvs.request();
+            auto clr_info = colors.request();
+            auto idx_info = indices.request();
+            py::gil_scoped_release release;
+            int num_verts = pos_info.shape[0];
+            int num_indices = idx_info.shape[0];
+            bool has_colors = (clr_info.size > 0);
+            auto* pos_ptr = static_cast<const float*>(pos_info.ptr);
+            auto* nrm_ptr = static_cast<const float*>(nrm_info.ptr);
+            auto* bin_ptr = static_cast<const float*>(bin_info.ptr);
+            auto* uv_ptr  = static_cast<const float*>(uv_info.ptr);
+            auto* clr_ptr = has_colors ? static_cast<const uint8_t*>(clr_info.ptr) : nullptr;
+            auto* idx_ptr = static_cast<const uint32_t*>(idx_info.ptr);
+
+            auto GBI = context->GBI();
+            using vtx_t = SVtxV12N12B12T8C4;
+            prim->_gpuClusters.clear();
+            auto cluster = std::make_shared<meshutil::rigidprim_V12N12B12T8C4_t::PrimGroupCluster>();
+            auto vtxbuf = std::make_shared<lev2::StaticVertexBuffer<vtx_t>>(num_verts, 0);
+            auto idxbuf = std::make_shared<lev2::StaticIndexBuffer<uint32_t>>(num_indices);
+            cluster->_vtxbuffer = vtxbuf;
+            auto PG = std::make_shared<meshutil::rigidprim_V12N12B12T8C4_t::PrimitiveGroup>();
+            cluster->_primgroups.push_back(PG);
+            PG->_primtype = lev2::PrimitiveType::TRIANGLES;
+            PG->_idxbuffer = idxbuf;
+            prim->_gpuClusters.push_back(cluster);
+
+            auto vtxptr = GBI->LockVB(*vtxbuf.get(), 0, num_verts);
+            auto* typed_verts = (vtx_t*)vtxptr;
+            for (int i = 0; i < num_verts; i++) {
+              auto& v = typed_verts[i];
+              v._position = fvec3(pos_ptr[i*3], pos_ptr[i*3+1], pos_ptr[i*3+2]);
+              v._normal   = fvec3(nrm_ptr[i*3], nrm_ptr[i*3+1], nrm_ptr[i*3+2]);
+              v._binormal = fvec3(bin_ptr[i*3], bin_ptr[i*3+1], bin_ptr[i*3+2]);
+              v._uv       = fvec2(uv_ptr[i*2], uv_ptr[i*2+1]);
+              v._color    = has_colors
+                          ? (uint32_t(clr_ptr[i*4]) | (uint32_t(clr_ptr[i*4+1])<<8) | (uint32_t(clr_ptr[i*4+2])<<16) | (uint32_t(clr_ptr[i*4+3])<<24))
+                          : 0xFFFFFFFF;
+            }
+            GBI->UnLockVB(*vtxbuf.get());
+
+            auto idxptr = GBI->LockIB(*idxbuf.get(), 0, num_indices);
+            auto* typed_idx = (uint32_t*)idxptr;
+            for (int i = 0; i < num_indices; i++) {
+              typed_idx[i] = idx_ptr[i];
+            }
+            GBI->UnLockIB(*idxbuf.get());
+          },
+          "Create rigid primitive directly from vertex attribute arrays, bypassing mesh processing",
+          py::arg("positions"), py::arg("normals"), py::arg("binormals"),
+          py::arg("uvs"), py::arg("colors"), py::arg("indices"), py::arg("context"));
 } // void pyinit_gfx_rigidprim(py::module& module_lev2) {
 } // namespace ork::lev2

--- a/ork.lev2/pyext/src/pyext_gfx_primitives_rigid.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_primitives_rigid.cpp
@@ -527,88 +527,9 @@ void pyinit_gfx_primitives_rigid(py::module& module_lev2) {
           py::arg("micromesh"),
           py::arg("context"),
           py::arg("primitive_type") = nullptr)
-      .def(
-          "fromVertsAndFacesDict",                         //
-          [](meshutil::rigidprim_V12N12B12T8C4_ptr_t prim, //
-             py::object verts,                             //
-             py::list faces,                               //
-             ctx_t context,                                //
-             crcstring_ptr_t primtype) {
-            ////////////////////////////////////////////
-            py::gil_scoped_release release;
-            auto micromesh = std::make_shared<MicroMesh>(verts, faces);
-            auto ptype = primtype ? PrimitiveType(primtype->hashed()) : PrimitiveType::TRIANGLES;
-            micromesh->updateRigidPrim(prim, nullptr, context, ptype);
-          },
-          "Create rigid primitive from vertices (list or numpy array (N,3) float32) and faces",
-          py::arg("verts"), py::arg("faces"), py::arg("context"), py::arg("primitive_type") = nullptr)
       .def("renderEML", [](meshutil::rigidprim_V12N12B12T8C4_ptr_t prim, ctx_t context) { //
         prim->renderEML(context.get());
       })
-      .def(
-          "fromArrays",
-          [](meshutil::rigidprim_V12N12B12T8C4_ptr_t prim,
-             py::buffer positions,   // (N,3) float32
-             py::buffer normals,     // (N,3) float32
-             py::buffer binormals,   // (N,3) float32
-             py::buffer uvs,         // (N,2) float32
-             py::buffer colors,      // (N,4) uint8 RGBA, or empty
-             py::buffer indices,     // (M,) uint32
-             ctx_t context) {
-            auto pos_info = positions.request();
-            auto nrm_info = normals.request();
-            auto bin_info = binormals.request();
-            auto uv_info  = uvs.request();
-            auto clr_info = colors.request();
-            auto idx_info = indices.request();
-            py::gil_scoped_release release;
-            int num_verts = pos_info.shape[0];
-            int num_indices = idx_info.shape[0];
-            bool has_colors = (clr_info.size > 0);
-            auto* pos_ptr = static_cast<const float*>(pos_info.ptr);
-            auto* nrm_ptr = static_cast<const float*>(nrm_info.ptr);
-            auto* bin_ptr = static_cast<const float*>(bin_info.ptr);
-            auto* uv_ptr  = static_cast<const float*>(uv_info.ptr);
-            auto* clr_ptr = has_colors ? static_cast<const uint8_t*>(clr_info.ptr) : nullptr;
-            auto* idx_ptr = static_cast<const uint32_t*>(idx_info.ptr);
-
-            auto GBI = context->GBI();
-            using vtx_t = SVtxV12N12B12T8C4;
-            prim->_gpuClusters.clear();
-            auto cluster = std::make_shared<meshutil::rigidprim_V12N12B12T8C4_t::PrimGroupCluster>();
-            auto vtxbuf = std::make_shared<lev2::StaticVertexBuffer<vtx_t>>(num_verts, 0);
-            auto idxbuf = std::make_shared<lev2::StaticIndexBuffer<uint32_t>>(num_indices);
-            cluster->_vtxbuffer = vtxbuf;
-            auto PG = std::make_shared<meshutil::rigidprim_V12N12B12T8C4_t::PrimitiveGroup>();
-            cluster->_primgroups.push_back(PG);
-            PG->_primtype = lev2::PrimitiveType::TRIANGLES;
-            PG->_idxbuffer = idxbuf;
-            prim->_gpuClusters.push_back(cluster);
-
-            auto vtxptr = GBI->LockVB(*vtxbuf.get(), 0, num_verts);
-            auto* typed_verts = (vtx_t*)vtxptr;
-            for (int i = 0; i < num_verts; i++) {
-              auto& v = typed_verts[i];
-              v._position = fvec3(pos_ptr[i*3], pos_ptr[i*3+1], pos_ptr[i*3+2]);
-              v._normal   = fvec3(nrm_ptr[i*3], nrm_ptr[i*3+1], nrm_ptr[i*3+2]);
-              v._binormal = fvec3(bin_ptr[i*3], bin_ptr[i*3+1], bin_ptr[i*3+2]);
-              v._uv       = fvec2(uv_ptr[i*2], uv_ptr[i*2+1]);
-              v._color    = has_colors
-                          ? (uint32_t(clr_ptr[i*4]) | (uint32_t(clr_ptr[i*4+1])<<8) | (uint32_t(clr_ptr[i*4+2])<<16) | (uint32_t(clr_ptr[i*4+3])<<24))
-                          : 0xFFFFFFFF;
-            }
-            GBI->UnLockVB(*vtxbuf.get());
-
-            auto idxptr = GBI->LockIB(*idxbuf.get(), 0, num_indices);
-            auto* typed_idx = (uint32_t*)idxptr;
-            for (int i = 0; i < num_indices; i++) {
-              typed_idx[i] = idx_ptr[i];
-            }
-            GBI->UnLockIB(*idxbuf.get());
-          },
-          "Create rigid primitive directly from vertex attribute arrays, bypassing mesh processing",
-          py::arg("positions"), py::arg("normals"), py::arg("binormals"),
-          py::arg("uvs"), py::arg("colors"), py::arg("indices"), py::arg("context"))
       .def(
           "createInstancedNode",
           [](meshutil::rigidprim_V12N12B12T8C4_ptr_t prim,

--- a/ork.lev2/pyext/src/pyext_gfx_primitives_rigid.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_primitives_rigid.cpp
@@ -608,6 +608,26 @@ void pyinit_gfx_primitives_rigid(py::module& module_lev2) {
           },
           "Create rigid primitive directly from vertex attribute arrays, bypassing mesh processing",
           py::arg("positions"), py::arg("normals"), py::arg("binormals"),
-          py::arg("uvs"), py::arg("colors"), py::arg("indices"), py::arg("context"));
+          py::arg("uvs"), py::arg("colors"), py::arg("indices"), py::arg("context"))
+      .def(
+          "createInstancedNode",
+          [](meshutil::rigidprim_V12N12B12T8C4_ptr_t prim,
+             int count,
+             std::string named,
+             scenegraph::layer_ptr_t layer,
+             material_ptr_t material) -> scenegraph::drawable_node_ptr_t {
+            using drw_t = meshutil::InstancedRigidPrimitiveDrawable<SVtxV12N12B12T8C4>;
+            auto drw = std::make_shared<drw_t>();
+            drw->bindPrimitive(prim, material);
+            drw->resize(count);
+            auto instdata = drw->_instancedata;
+            for (int i = 0; i < count; i++) {
+              instdata->_worldmatrices[i].compose(fvec3(0, 0, 0), fquat(), 0.0f);
+              instdata->_modcolors[i] = fvec4(1, 1, 1, 1);
+            }
+            auto node = layer->createDrawableNode(named, drw);
+            return node;
+          },
+          py::arg("count"), py::arg("name"), py::arg("layer"), py::arg("material"));
 } // void pyinit_gfx_rigidprim(py::module& module_lev2) {
 } // namespace ork::lev2

--- a/ork.lev2/pyext/src/pyext_gfx_scenegraph.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_scenegraph.cpp
@@ -128,7 +128,7 @@ void pyinit_scenegraph(py::module& module_lev2) {
               "instanceData",
               [](drawable_node_ptr_t drwnode) -> instanceddrawinstancedata_ptr_t {
                 auto drw     = drwnode->_drawable;
-                auto instdrw = std::dynamic_pointer_cast<InstancedModelDrawable>(drw);
+                auto instdrw = std::dynamic_pointer_cast<InstancedDrawable>(drw);
                 instanceddrawinstancedata_ptr_t rval;
                 if (instdrw) {
                   rval = instdrw->_instancedata;
@@ -141,7 +141,7 @@ void pyinit_scenegraph(py::module& module_lev2) {
               "setInstanceMatrix",                                       //
               [](drawable_node_ptr_t node, int instance, fmtx4 matrix) { //
                 auto drw     = node->_drawable;
-                auto instdrw = std::dynamic_pointer_cast<InstancedModelDrawable>(drw);
+                auto instdrw = std::dynamic_pointer_cast<InstancedDrawable>(drw);
                 if (instdrw) {
                   auto instdata                      = instdrw->_instancedata;
                   instdata->_worldmatrices[instance] = matrix;
@@ -154,7 +154,7 @@ void pyinit_scenegraph(py::module& module_lev2) {
               "setInstanceColor",                                             //
               [](drawable_node_ptr_t node, int instance, fvec4 color) { //
                 auto drw     = node->_drawable;
-                auto instdrw = std::dynamic_pointer_cast<InstancedModelDrawable>(drw);
+                auto instdrw = std::dynamic_pointer_cast<InstancedDrawable>(drw);
                 if (instdrw) {
                   auto instdata                  = instdrw->_instancedata;
                   instdata->_modcolors[instance] = color;

--- a/ork.lev2/pyext/src/pyext_micromesh.inl
+++ b/ork.lev2/pyext/src/pyext_micromesh.inl
@@ -92,6 +92,25 @@ inline void loadVec3Data(std::vector<fvec3>& out_verts, py::object input) {
 }
 
 ///////////////////////////////////////
+// Like loadVec3Data but produces fvec4 from (N,3) (alpha=1) or (N,4) input.
+inline void loadVec4Data(std::vector<fvec4>& out_colors, py::object input) {
+  if (py::isinstance<py::buffer>(input)) {
+    auto info = input.cast<py::buffer>().request();
+    OrkAssert(info.format == py::format_descriptor<float>::format());
+    OrkAssert(info.ndim == 2 && (info.shape[1] == 3 || info.shape[1] == 4));
+    size_t n = info.shape[0], ch = info.shape[1];
+    size_t s0 = info.strides[0]/sizeof(float), s1 = info.strides[1]/sizeof(float);
+    float* p = static_cast<float*>(info.ptr);
+    out_colors.reserve(n);
+    for (size_t i = 0; i < n; i++)
+      out_colors.push_back(fvec4(p[i*s0], p[i*s0+s1], p[i*s0+2*s1],
+                                 ch == 4 ? p[i*s0+3*s1] : 1.0f));
+  } else {
+    for (const auto& c : input.cast<py::list>()) out_colors.push_back(c.cast<fvec4>());
+  }
+}
+
+///////////////////////////////////////
 
 inline void loadVec2Data(std::vector<fvec2>& out_uvs, py::object input) {
   // Try buffer protocol first (numpy arrays, etc.)
@@ -184,7 +203,7 @@ struct MicroMesh {
                        lev2::PrimitiveType primtype = lev2::PrimitiveType::TRIANGLES) const;
 
   std::vector<fvec3> _vertices;
-  std::vector<fvec3> _colors;
+  std::vector<fvec4> _colors;
   std::vector<fvec3> _normals;
   std::vector<fvec2> _uvs;        // Optional UV coordinates
   std::vector<fvec3> _binormals;  // Optional binormals (tangent space)
@@ -216,7 +235,7 @@ inline void MicroMesh::updateVertices(py::object vert_data) {
   loadVec3Data(_vertices, vert_data);
 
   // Initialize colors
-  _colors.resize(_vertices.size(), fvec3(1.0f, 1.0f, 1.0f));
+  _colors.resize(_vertices.size(), fvec4(1.0f, 1.0f, 1.0f, 1.0f));
 
   // Topology unchanged, connectivity still valid
 }
@@ -235,7 +254,7 @@ inline void MicroMesh::updateFromLists(py::object vert_data, py::list face_list)
   loadVec3Data(_vertices, vert_data);
 
   // Initialize colors
-  _colors.resize(_vertices.size(), fvec3(1.0f, 1.0f, 1.0f));
+  _colors.resize(_vertices.size(), fvec4(1.0f, 1.0f, 1.0f, 1.0f));
 
   // Load faces
   bool done_with_faces     = false;
@@ -684,11 +703,9 @@ inline void MicroMesh::updateNormals(py::object normal_data) {
 ///////////////////////////////////////
 
 inline void MicroMesh::updateColors(py::object color_data) {
-  // Update colors from pre-generated list or numpy array
+  // Update colors from pre-generated list or numpy array (RGB or RGBA)
   _colors.clear();
-
-  // Load colors using helper (supports py::list or numpy)
-  loadVec3Data(_colors, color_data);
+  loadVec4Data(_colors, color_data);
 }
 
 ///////////////////////////////////////

--- a/ork.lev2/pyext/src/pyext_micromesh.inl
+++ b/ork.lev2/pyext/src/pyext_micromesh.inl
@@ -276,18 +276,18 @@ inline void MicroMesh::updateFromLists(py::object vert_data, py::list face_list)
         }
         case 3: {
           auto& out_tri = _tris.emplace_back();
-          out_tri.push_back(face_list[iidx+2].cast<int>());
-          out_tri.push_back(face_list[iidx+1].cast<int>());
           out_tri.push_back(face_list[iidx+0].cast<int>());
+          out_tri.push_back(face_list[iidx+1].cast<int>());
+          out_tri.push_back(face_list[iidx+2].cast<int>());
           iidx += 3;
           break;
         }
         case 4: {
           auto& out_quad = _quads.emplace_back();
-          out_quad.push_back(face_list[iidx+3].cast<int>());
-          out_quad.push_back(face_list[iidx+2].cast<int>());
-          out_quad.push_back(face_list[iidx+1].cast<int>());
           out_quad.push_back(face_list[iidx+0].cast<int>());
+          out_quad.push_back(face_list[iidx+1].cast<int>());
+          out_quad.push_back(face_list[iidx+2].cast<int>());
+          out_quad.push_back(face_list[iidx+3].cast<int>());
           iidx += 4;
           break;
         }

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env ork.python
+
+################################################################################
+# Basic Procedural Cube + Orbiting Point Light Test
+# Minimal test: one cube, one orbiting point light with indicator sphere.
+# Copyright 1996-2023, Michael T. Mayers.
+# Distributed under the MIT License
+# see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+################################################################################
+
+import math, sys, signal, argparse
+import numpy as np
+from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
+from orkengine import lev2
+from orkengine.lev2 import RigidPrimitive
+
+lev2_pyexdir.addToSysPath()
+
+parser = argparse.ArgumentParser(description='basic cube+sphere+light test')
+parser.add_argument('--gold', action='store_true', help='use gold material instead of chalk')
+args = parser.parse_args()
+from lev2utils.cameras import setupUiCamera
+from lev2utils.primitives import createGridData
+from lev2utils.scenegraph import createSceneGraph
+
+tokens = CrcStringProxy()
+
+################################################################################
+
+def make_cube_arrays(size=1.0):
+  h = size / 2.0
+  face_data = [
+    ((0,0,1),  [(-h,-h,h),(h,-h,h),(h,h,h),(-h,h,h)]),
+    ((0,0,-1), [(h,-h,-h),(-h,-h,-h),(-h,h,-h),(h,h,-h)]),
+    ((1,0,0),  [(h,-h,h),(h,-h,-h),(h,h,-h),(h,h,h)]),
+    ((-1,0,0), [(-h,-h,-h),(-h,-h,h),(-h,h,h),(-h,h,-h)]),
+    ((0,1,0),  [(-h,h,h),(h,h,h),(h,h,-h),(-h,h,-h)]),
+    ((0,-1,0), [(-h,-h,-h),(h,-h,-h),(h,-h,h),(-h,-h,h)]),
+  ]
+  verts, norms, indices = [], [], []
+  for (nx, ny, nz), corners in face_data:
+    base = len(verts)
+    for c in corners:
+      verts.append(c)
+      norms.append((nx, ny, nz))
+    indices.extend([base, base+2, base+1, base, base+3, base+2])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  binormals_np = np.zeros((nv, 3), dtype=np.float32)
+  binormals_np[:, 0] = 1.0
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  indices_np = np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+
+def make_sphere_arrays(radius=1.0, n=8):
+  verts, norms = [], []
+  for i in range(n + 1):
+    lat = math.pi * i / n
+    for j in range(n * 2):
+      lon = math.tau * j / (n * 2)
+      x = math.sin(lat) * math.cos(lon)
+      y = math.cos(lat)
+      z = math.sin(lat) * math.sin(lon)
+      verts.append((x * radius, y * radius, z * radius))
+      norms.append((x, y, z))
+  w = n * 2
+  indices = []
+  for i in range(n):
+    for j in range(w):
+      a = i * w + j
+      b = a + 1 if j < w - 1 else i * w
+      c = a + w
+      d = c + 1 if j < w - 1 else (i + 1) * w
+      indices.extend([a, c, b, b, c, d])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  up = np.array([0, 1, 0], dtype=np.float32)
+  binormals_np = np.cross(norms_np, up)
+  degen = np.linalg.norm(binormals_np, axis=1) < 1e-6
+  binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
+  lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
+  binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+
+################################################################################
+
+class BasicCubeLightApp(object):
+
+  def __init__(self):
+    super().__init__()
+    self.ezapp = lev2.OrkEzApp.create(self, width=1280, height=720)
+    self.ezapp.setRefreshPolicy(lev2.RefreshFastest, 0)
+    setupUiCamera(app=self, eye=vec3(3, 2.5, 3), tgt=vec3(0, 0.5, 0))
+    signal.signal(signal.SIGINT, lambda s, f: self.ezapp.signalExit())
+    self.time = 0.0
+
+  def onGpuInit(self, ctx):
+    createSceneGraph(app=self, params_dict={
+      "SkyboxTexPathStr": "ork_envmaps|tozenv_basic",
+      "SkyboxIntensity": float(1),
+    })
+
+    white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
+    normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
+
+    # Material properties
+    if args.gold:
+      obj_color = (0.8, 0.7, 0.2)
+      roughness, metallic = 0.3, 1.0
+    else:
+      obj_color = (0.8, 0.75, 0.7)
+      roughness, metallic = 1.0, 0.0
+
+    # Cube
+    cv, cn, cb, cu, ci = make_cube_arrays(size=1.0)
+    nv = len(cv)
+    colors_np = np.zeros((nv, 4), dtype=np.uint8)
+    colors_np[:, 0] = int(obj_color[0] * 255)
+    colors_np[:, 1] = int(obj_color[1] * 255)
+    colors_np[:, 2] = int(obj_color[2] * 255)
+    colors_np[:, 3] = 255
+    self.cube_prim = RigidPrimitive()
+    self.cube_prim.fromArrays(cv, cn, cb, cu, colors_np, ci, ctx)
+    cube_mtl = lev2.PBRMaterial()
+    cube_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+    cube_mtl.baseColor = vec4(1, 1, 1, 1)
+    cube_mtl.roughnessFactor = roughness
+    cube_mtl.metallicFactor = metallic
+    cube_mtl.gpuInit(ctx)
+    self.cube_mtl = cube_mtl
+    self.cube_node = self.cube_prim.createNode("cube", self.layer1, cube_mtl)
+    self.cube_node.worldTransform.translation = vec3(-0.8, 0, 0)
+    self.cube_node.sortkey = 10
+
+    # Sphere next to the cube (same material)
+    sv_obj, sn_obj, sb_obj, su_obj, si_obj = make_sphere_arrays(0.6, 12)
+    nv_obj = len(sv_obj)
+    sphere_colors = np.zeros((nv_obj, 4), dtype=np.uint8)
+    sphere_colors[:, 0] = int(obj_color[0] * 255)
+    sphere_colors[:, 1] = int(obj_color[1] * 255)
+    sphere_colors[:, 2] = int(obj_color[2] * 255)
+    sphere_colors[:, 3] = 255
+    self.sphere_prim = RigidPrimitive()
+    self.sphere_prim.fromArrays(sv_obj, sn_obj, sb_obj, su_obj, sphere_colors, si_obj, ctx)
+    sphere_mtl = lev2.PBRMaterial()
+    sphere_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+    sphere_mtl.baseColor = vec4(1, 1, 1, 1)
+    sphere_mtl.roughnessFactor = roughness
+    sphere_mtl.metallicFactor = metallic
+    sphere_mtl.gpuInit(ctx)
+    self.sphere_mtl = sphere_mtl
+    self.sphere_node = self.sphere_prim.createNode("sphere", self.layer1, sphere_mtl)
+    self.sphere_node.worldTransform.translation = vec3(0.8, 0, 0)
+    self.sphere_node.sortkey = 10
+
+    # Light indicator sphere
+    sv, sn, sb, su, si = make_sphere_arrays(0.08, 6)
+    nv_s = len(sv)
+    orb_colors = np.full((nv_s, 4), 255, dtype=np.uint8)
+    self.orb_prim = RigidPrimitive()
+    self.orb_prim.fromArrays(sv, sn, sb, su, orb_colors, si, ctx)
+    orb_mtl = lev2.PBRMaterial()
+    orb_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+    orb_mtl.baseColor = vec4(1, 1, 1, 1)
+    orb_mtl.roughnessFactor = 0.0
+    orb_mtl.metallicFactor = 0.0
+    orb_mtl.gpuInit(ctx)
+    self.orb_mtl = orb_mtl
+    self.orb_node = self.orb_prim.createNode("orb", self.layer1, orb_mtl)
+    self.orb_node.sortkey = 10
+
+    # Point light
+    self.light = lev2.DynamicPointLight()
+    self.light.data.color = vec3(1, 1, 1)
+    self.light.data.intensity = 5.0
+    self.light.data.radius = 5.0
+    self.light_node = self.layer1.createLightNode("orbit_light", self.light)
+
+    self.scene.lightingmanager.gpuInit(ctx)
+
+  def onGpuUpdate(self, ctx):
+    t = self.time
+    angle = t * 1.0
+    x = 2.0 * math.cos(angle)
+    z = 2.0 * math.sin(angle)
+    y = 1.0
+    self.light_node.setMatrix(mtx4.transMatrix(vec3(x, y, z)))
+    self.orb_node.worldTransform.translation = vec3(x, y, z)
+
+  def onUiEvent(self, uievent):
+    handled = self.uicam.uiEventHandler(uievent)
+    if handled:
+      self.camera.copyFrom(self.uicam.cameradata)
+    return lev2.ui.HandlerResult()
+
+  def onUpdate(self, updinfo):
+    self.time = updinfo.absolutetime
+    self.scene.updateScene(self.cameralut)
+
+################################################################################
+
+if __name__ == "__main__":
+  app = BasicCubeLightApp()
+  app.ezapp.mainThreadLoop()

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py
@@ -137,6 +137,7 @@ class BasicCubeLightApp(object):
       mtl.baseColor = vec4(1, 1, 1, 1)
       mtl.roughnessFactor = roughness
       mtl.metallicFactor = metallic
+      mtl.doubleSided = True  # lit on both sides; exercises the engine's dynamic cull path
       mtl.gpuInit(ctx)
       return mtl
 

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py
@@ -12,7 +12,7 @@ import math, sys, signal, argparse
 import numpy as np
 from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
 from orkengine import lev2
-from orkengine.lev2 import RigidPrimitive
+from orkengine.lev2 import RigidPrimitive, MicroMesh
 
 lev2_pyexdir.addToSysPath()
 
@@ -28,6 +28,10 @@ tokens = CrcStringProxy()
 ################################################################################
 
 def make_cube_arrays(size=1.0):
+  # Returns (verts_np, norms_np, binormals_np, faces).
+  # `faces` is a flat [count, i0, i1, i2, ...] list with CCW-from-outside
+  # winding (the natural authored direction). MicroMesh.fromVertAndFaceLists
+  # reverses winding internally to match the vertex-color forward technique.
   h = size / 2.0
   face_data = [
     ((0,0,1),  [(-h,-h,h),(h,-h,h),(h,h,h),(-h,h,h)]),
@@ -37,23 +41,22 @@ def make_cube_arrays(size=1.0):
     ((0,1,0),  [(-h,h,h),(h,h,h),(h,h,-h),(-h,h,-h)]),
     ((0,-1,0), [(-h,-h,-h),(h,-h,-h),(h,-h,h),(-h,-h,h)]),
   ]
-  verts, norms, indices = [], [], []
+  verts, norms, faces = [], [], []
   for (nx, ny, nz), corners in face_data:
     base = len(verts)
     for c in corners:
       verts.append(c)
       norms.append((nx, ny, nz))
-    indices.extend([base, base+2, base+1, base, base+3, base+2])
+    faces.extend([3, base, base+1, base+2, 3, base, base+2, base+3])
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
   binormals_np = np.zeros((nv, 3), dtype=np.float32)
   binormals_np[:, 0] = 1.0
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  indices_np = np.array(indices, dtype=np.uint32)
-  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+  return verts_np, norms_np, binormals_np, faces
 
 def make_sphere_arrays(radius=1.0, n=8):
+  # Same convention as make_cube_arrays: faces are CCW-from-outside.
   verts, norms = [], []
   for i in range(n + 1):
     lat = math.pi * i / n
@@ -65,14 +68,14 @@ def make_sphere_arrays(radius=1.0, n=8):
       verts.append((x * radius, y * radius, z * radius))
       norms.append((x, y, z))
   w = n * 2
-  indices = []
+  faces = []
   for i in range(n):
     for j in range(w):
       a = i * w + j
       b = a + 1 if j < w - 1 else i * w
       c = a + w
       d = c + 1 if j < w - 1 else (i + 1) * w
-      indices.extend([a, c, b, b, c, d])
+      faces.extend([3, a, b, c, 3, b, d, c])
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
@@ -82,8 +85,7 @@ def make_sphere_arrays(radius=1.0, n=8):
   binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
   lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
   binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, faces
 
 ################################################################################
 
@@ -114,62 +116,51 @@ class BasicCubeLightApp(object):
       obj_color = (0.8, 0.75, 0.7)
       roughness, metallic = 1.0, 0.0
 
+    def make_solid_color_prim(verts, norms, binormals, faces, color):
+      n = len(verts)
+      # BGRA pre-swap: MicroMesh::updateRigidPrim packs colors via
+      # fvec4::ARGBU32 which lands as BGRA in memory; the GPU reads RGBA.
+      colors = np.tile(np.array([color[2], color[1], color[0], 1.0],
+                                dtype=np.float32), (n, 1))
+      mesh = MicroMesh.fromVertAndFaceLists(verts, faces)
+      mesh.updateNormals(norms)
+      mesh.updateBinormals(binormals)
+      mesh.updateColors(colors)
+      prim = RigidPrimitive()
+      prim.updateWithMicroMesh(mesh, ctx, tokens.TRIANGLES)
+      return prim
+
+    def make_pbr_material(roughness, metallic):
+      mtl = lev2.PBRMaterial()
+      mtl.assignImages(ctx, color=white_img, normal=normal_img,
+                       mtlruf=white_img, doConform=True)
+      mtl.baseColor = vec4(1, 1, 1, 1)
+      mtl.roughnessFactor = roughness
+      mtl.metallicFactor = metallic
+      mtl.gpuInit(ctx)
+      return mtl
+
     # Cube
-    cv, cn, cb, cu, ci = make_cube_arrays(size=1.0)
-    nv = len(cv)
-    colors_np = np.zeros((nv, 4), dtype=np.uint8)
-    colors_np[:, 0] = int(obj_color[0] * 255)
-    colors_np[:, 1] = int(obj_color[1] * 255)
-    colors_np[:, 2] = int(obj_color[2] * 255)
-    colors_np[:, 3] = 255
-    self.cube_prim = RigidPrimitive()
-    self.cube_prim.fromArrays(cv, cn, cb, cu, colors_np, ci, ctx)
-    cube_mtl = lev2.PBRMaterial()
-    cube_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
-    cube_mtl.baseColor = vec4(1, 1, 1, 1)
-    cube_mtl.roughnessFactor = roughness
-    cube_mtl.metallicFactor = metallic
-    cube_mtl.gpuInit(ctx)
-    self.cube_mtl = cube_mtl
-    self.cube_node = self.cube_prim.createNode("cube", self.layer1, cube_mtl)
+    cv, cn, cb, cf = make_cube_arrays(size=1.0)
+    self.cube_prim = make_solid_color_prim(cv, cn, cb, cf, obj_color)
+    self.cube_mtl = make_pbr_material(roughness, metallic)
+    self.cube_node = self.cube_prim.createNode("cube", self.layer1, self.cube_mtl)
     self.cube_node.worldTransform.translation = vec3(-0.8, 0, 0)
     self.cube_node.sortkey = 10
 
     # Sphere next to the cube (same material)
-    sv_obj, sn_obj, sb_obj, su_obj, si_obj = make_sphere_arrays(0.6, 12)
-    nv_obj = len(sv_obj)
-    sphere_colors = np.zeros((nv_obj, 4), dtype=np.uint8)
-    sphere_colors[:, 0] = int(obj_color[0] * 255)
-    sphere_colors[:, 1] = int(obj_color[1] * 255)
-    sphere_colors[:, 2] = int(obj_color[2] * 255)
-    sphere_colors[:, 3] = 255
-    self.sphere_prim = RigidPrimitive()
-    self.sphere_prim.fromArrays(sv_obj, sn_obj, sb_obj, su_obj, sphere_colors, si_obj, ctx)
-    sphere_mtl = lev2.PBRMaterial()
-    sphere_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
-    sphere_mtl.baseColor = vec4(1, 1, 1, 1)
-    sphere_mtl.roughnessFactor = roughness
-    sphere_mtl.metallicFactor = metallic
-    sphere_mtl.gpuInit(ctx)
-    self.sphere_mtl = sphere_mtl
-    self.sphere_node = self.sphere_prim.createNode("sphere", self.layer1, sphere_mtl)
+    sv_obj, sn_obj, sb_obj, sf_obj = make_sphere_arrays(0.6, 12)
+    self.sphere_prim = make_solid_color_prim(sv_obj, sn_obj, sb_obj, sf_obj, obj_color)
+    self.sphere_mtl = make_pbr_material(roughness, metallic)
+    self.sphere_node = self.sphere_prim.createNode("sphere", self.layer1, self.sphere_mtl)
     self.sphere_node.worldTransform.translation = vec3(0.8, 0, 0)
     self.sphere_node.sortkey = 10
 
     # Light indicator sphere
-    sv, sn, sb, su, si = make_sphere_arrays(0.08, 6)
-    nv_s = len(sv)
-    orb_colors = np.full((nv_s, 4), 255, dtype=np.uint8)
-    self.orb_prim = RigidPrimitive()
-    self.orb_prim.fromArrays(sv, sn, sb, su, orb_colors, si, ctx)
-    orb_mtl = lev2.PBRMaterial()
-    orb_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
-    orb_mtl.baseColor = vec4(1, 1, 1, 1)
-    orb_mtl.roughnessFactor = 0.0
-    orb_mtl.metallicFactor = 0.0
-    orb_mtl.gpuInit(ctx)
-    self.orb_mtl = orb_mtl
-    self.orb_node = self.orb_prim.createNode("orb", self.layer1, orb_mtl)
+    sv, sn, sb, sf = make_sphere_arrays(0.08, 6)
+    self.orb_prim = make_solid_color_prim(sv, sn, sb, sf, (1.0, 1.0, 1.0))
+    self.orb_mtl = make_pbr_material(0.0, 0.0)
+    self.orb_node = self.orb_prim.createNode("orb", self.layer1, self.orb_mtl)
     self.orb_node.sortkey = 10
 
     # Point light

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
@@ -78,16 +78,17 @@ class InstancingApp(object):
   ##############################################
 
   def onGpuInit(self, ctx):
-    createSceneGraph(app=self)
+    createSceneGraph(app=self, params_dict={
+      "SkyboxTexPathStr": "ork_envmaps|cold4k",
+      "SkyboxIntensity": float(1),
+    })
 
     self.grid_data = createGridData()
     self.grid_node = self.layer1.createDrawableNodeFromData("grid", self.grid_data)
     self.grid_node.sortkey = 1
 
-    white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.full((4, 4, 4), 255, dtype=np.uint8))
-    normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+    white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
+    normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
     sv, sn, sb, su, si = make_sphere_arrays(1.0, 8)
     nv = len(sv)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env ork.python
+
+################################################################################
+# GPU Instanced Procedural Geometry Test
+# Demonstrates InstancedRigidPrimitiveDrawable:
+# - Instanced rendering of procedural meshes via SSBO
+# - Per-instance transforms (position, rotation, scale) via world matrices
+# - Per-instance colors multiplied with per-vertex colors
+# - Opaque and transparent instanced objects
+# - Time-varying per-instance animation
+# Copyright 1996-2023, Michael T. Mayers.
+# Distributed under the MIT License
+# see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+################################################################################
+
+import math, sys, signal, random
+import numpy as np
+from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
+from orkengine import lev2
+from orkengine.lev2 import RigidPrimitive
+
+lev2_pyexdir.addToSysPath()
+from lev2utils.cameras import setupUiCamera
+from lev2utils.primitives import createGridData
+from lev2utils.scenegraph import createSceneGraph
+
+tokens = CrcStringProxy()
+
+NUM_OPAQUE = 500
+NUM_TRANSPARENT = 200
+
+################################################################################
+
+def make_sphere_arrays(radius=1.0, n=8):
+  verts, norms = [], []
+  for i in range(n + 1):
+    lat = math.pi * i / n
+    for j in range(n * 2):
+      lon = math.tau * j / (n * 2)
+      x = math.sin(lat) * math.cos(lon)
+      y = math.cos(lat)
+      z = math.sin(lat) * math.sin(lon)
+      verts.append((x * radius, y * radius, z * radius))
+      norms.append((x, y, z))
+  w = n * 2
+  indices = []
+  for i in range(n):
+    for j in range(w):
+      a = i * w + j
+      b = a + 1 if j < w - 1 else i * w
+      c = a + w
+      d = c + 1 if j < w - 1 else (i + 1) * w
+      indices.extend([a, c, b, b, c, d])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  up = np.array([0, 1, 0], dtype=np.float32)
+  binormals_np = np.cross(norms_np, up)
+  degen = np.linalg.norm(binormals_np, axis=1) < 1e-6
+  binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
+  lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
+  binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+
+################################################################################
+
+class InstancingApp(object):
+
+  def __init__(self):
+    super().__init__()
+    self.ezapp = lev2.OrkEzApp.create(self, width=1280, height=720)
+    self.ezapp.setRefreshPolicy(lev2.RefreshFastest, 0)
+    setupUiCamera(app=self, eye=vec3(0, 8, 20), tgt=vec3(0, 2, 0))
+    signal.signal(signal.SIGINT, lambda s, f: self.ezapp.signalExit())
+    self.time = 0.0
+
+  ##############################################
+
+  def onGpuInit(self, ctx):
+    createSceneGraph(app=self)
+
+    self.grid_data = createGridData()
+    self.grid_node = self.layer1.createDrawableNodeFromData("grid", self.grid_data)
+    self.grid_node.sortkey = 1
+
+    white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.full((4, 4, 4), 255, dtype=np.uint8))
+    normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+
+    sv, sn, sb, su, si = make_sphere_arrays(1.0, 8)
+    nv = len(sv)
+
+    ##################################
+    # Opaque instanced spheres
+    ##################################
+    colors_opaque = np.zeros((nv, 4), dtype=np.uint8)
+    colors_opaque[:, 0] = 200
+    colors_opaque[:, 1] = 200
+    colors_opaque[:, 2] = 200
+    colors_opaque[:, 3] = 255
+
+    prim_opaque = RigidPrimitive()
+    prim_opaque.fromArrays(sv, sn, sb, su, colors_opaque, si, ctx)
+
+    mtl_opaque = lev2.PBRMaterial()
+    mtl_opaque.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+    mtl_opaque.baseColor = vec4(1, 1, 1, 1)
+    mtl_opaque.roughnessFactor = 0.5
+    mtl_opaque.metallicFactor = 0.0
+    mtl_opaque.gpuInit(ctx)
+
+    self.opaque_node = prim_opaque.createInstancedNode(NUM_OPAQUE, "opaque_spheres", self.layer1, mtl_opaque)
+    self.opaque_node.sortkey = 10
+    self.opaque_instdata = self.opaque_node.instanceData
+
+    # Initialize opaque instance data
+    self.opaque_data = []
+    matrices = np.array(self.opaque_instdata.matrices, copy=False)
+    colors = np.array(self.opaque_instdata.colors, copy=False)
+    for i in range(NUM_OPAQUE):
+      x = random.uniform(-10, 10)
+      z = random.uniform(-10, 10)
+      y = random.uniform(0.5, 5)
+      s = random.uniform(0.1, 0.4)
+      phase = random.uniform(0, math.tau)
+      speed = random.uniform(0.3, 1.0)
+      # Random warm color
+      cr = random.uniform(0.1, 0.25)
+      cg = random.uniform(0.05, 0.15)
+      cb = random.uniform(0.03, 0.1)
+      self.opaque_data.append((x, y, z, s, phase, speed, cr, cg, cb))
+      m = mtx4.composed(vec3(x, y, z), quat(), s)
+      matrices[i] = np.array(m, copy=False)
+      colors[i] = (cr, cg, cb, 1.0)
+
+    ##################################
+    # Transparent instanced spheres
+    ##################################
+    colors_trans = np.zeros((nv, 4), dtype=np.uint8)
+    colors_trans[:, 0] = 230
+    colors_trans[:, 1] = 240
+    colors_trans[:, 2] = 255
+    colors_trans[:, 3] = 255  # vertex alpha = 1, instance alpha controls opacity
+
+    prim_trans = RigidPrimitive()
+    prim_trans.fromArrays(sv, sn, sb, su, colors_trans, si, ctx)
+
+    mtl_trans = lev2.PBRMaterial()
+    mtl_trans.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+    mtl_trans.baseColor = vec4(1, 1, 1, 1)
+    mtl_trans.roughnessFactor = 0.0
+    mtl_trans.metallicFactor = 1.0
+    mtl_trans.alphaBlend = True
+    mtl_trans.gpuInit(ctx)
+
+    self.trans_node = prim_trans.createInstancedNode(NUM_TRANSPARENT, "trans_spheres", self.layer1, mtl_trans)
+    self.trans_node.sortkey = 20
+    self.trans_instdata = self.trans_node.instanceData
+
+    # Initialize transparent instance data
+    self.trans_data = []
+    matrices = np.array(self.trans_instdata.matrices, copy=False)
+    colors = np.array(self.trans_instdata.colors, copy=False)
+    for i in range(NUM_TRANSPARENT):
+      x = random.uniform(-8, 8)
+      z = random.uniform(-8, 8)
+      y = random.uniform(1, 6)
+      s = random.uniform(0.2, 0.6)
+      phase = random.uniform(0, math.tau)
+      speed = random.uniform(0.5, 1.5)
+      birth = random.uniform(-5, 0)
+      lifetime = random.uniform(3, 8)
+      self.trans_data.append((x, y, z, s, phase, speed, birth, lifetime))
+      m = mtx4.composed(vec3(x, y, z), quat(), s)
+      matrices[i] = np.array(m, copy=False)
+      colors[i] = (0.9, 0.95, 1.0, 0.4)
+
+    # Keep materials alive
+    self.materials = [mtl_opaque, mtl_trans]
+    self.prims = [prim_opaque, prim_trans]
+
+    # Lighting
+    light = lev2.DynamicPointLight()
+    light.data.color = vec3(1, 0.95, 0.85)
+    light.data.intensity = 8.0
+    light.data.radius = 30.0
+    self.light_node = light.data.createNode("sun", self.layer1)
+    self.light_node.worldTransform.translation = vec3(5, 10, 5)
+    self.light = light
+
+    self.scene.lightingmanager.gpuInit(ctx)
+
+    print(f"Instancing Test: {NUM_OPAQUE} opaque + {NUM_TRANSPARENT} transparent spheres")
+
+  ##############################################
+
+  def onGpuUpdate(self, ctx):
+    t = self.time
+
+    # Animate opaque instances: gentle bobbing
+    matrices = np.array(self.opaque_instdata.matrices, copy=False)
+    for i in range(NUM_OPAQUE):
+      x, y_base, z, s, phase, speed, cr, cg, cb = self.opaque_data[i]
+      y = y_base + math.sin(t * speed + phase) * 0.3
+      m = mtx4.composed(vec3(x, y, z), quat(vec3(0, 1, 0), t * speed + phase), s)
+      matrices[i] = np.array(m, copy=False)
+
+    # Animate transparent instances: fade in/out lifecycle
+    matrices = np.array(self.trans_instdata.matrices, copy=False)
+    colors = np.array(self.trans_instdata.colors, copy=False)
+    for i in range(NUM_TRANSPARENT):
+      x, y_base, z, s, phase, speed, birth, lifetime = self.trans_data[i]
+      age = t - birth
+      # Wrap around
+      cycle_age = age % lifetime
+      fade = 1.0 - (cycle_age / lifetime) ** 1.5
+      alpha = max(0.0, 0.5 * fade)
+      y = y_base + math.sin(t * speed + phase) * 0.5
+      m = mtx4.composed(vec3(x, y, z), quat(), s * (0.5 + 0.5 * fade))
+      matrices[i] = np.array(m, copy=False)
+      colors[i] = (0.9, 0.95, 1.0, alpha)
+
+  def onUiEvent(self, uievent):
+    handled = self.uicam.uiEventHandler(uievent)
+    if handled:
+      self.camera.copyFrom(self.uicam.cameradata)
+    return lev2.ui.HandlerResult()
+
+  def onUpdate(self, updinfo):
+    self.time = updinfo.absolutetime
+    self.scene.updateScene(self.cameralut)
+
+################################################################################
+
+if __name__ == "__main__":
+  app = InstancingApp()
+  app.ezapp.mainThreadLoop()

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
@@ -26,7 +26,8 @@ from lev2utils.scenegraph import createSceneGraph
 
 tokens = CrcStringProxy()
 
-NUM_OPAQUE = 500
+NUM_SPHERES = 300
+NUM_CUBES = 200
 NUM_TRANSPARENT = 200
 
 ################################################################################
@@ -63,6 +64,31 @@ def make_sphere_arrays(radius=1.0, n=8):
   uvs_np = np.zeros((nv, 2), dtype=np.float32)
   return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
 
+def make_cube_arrays(size=1.0):
+  h = size / 2.0
+  face_data = [
+    ((0,0,1),  [(-h,-h,h),(h,-h,h),(h,h,h),(-h,h,h)]),
+    ((0,0,-1), [(h,-h,-h),(-h,-h,-h),(-h,h,-h),(h,h,-h)]),
+    ((1,0,0),  [(h,-h,h),(h,-h,-h),(h,h,-h),(h,h,h)]),
+    ((-1,0,0), [(-h,-h,-h),(-h,-h,h),(-h,h,h),(-h,h,-h)]),
+    ((0,1,0),  [(-h,h,h),(h,h,h),(h,h,-h),(-h,h,-h)]),
+    ((0,-1,0), [(-h,-h,-h),(h,-h,-h),(h,-h,h),(-h,-h,h)]),
+  ]
+  verts, norms, indices = [], [], []
+  for (nx, ny, nz), corners in face_data:
+    base = len(verts)
+    for c in corners:
+      verts.append(c)
+      norms.append((nx, ny, nz))
+    indices.extend([base, base+2, base+1, base, base+3, base+2])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  binormals_np = np.zeros((nv, 3), dtype=np.float32)
+  binormals_np[:, 0] = 1.0
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+
 ################################################################################
 
 class InstancingApp(object):
@@ -90,44 +116,78 @@ class InstancingApp(object):
     white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
     normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
-    sv, sn, sb, su, si = make_sphere_arrays(1.0, 8)
-    nv = len(sv)
+    self.materials = []
+    self.prims = []
+
+    def make_instanced_set(mesh_arrays, count, name, roughness, metallic, alpha_blend=False):
+      v, n, b, u, idx = mesh_arrays
+      nv = len(v)
+      vc = np.full((nv, 4), 255, dtype=np.uint8)
+      prim = RigidPrimitive()
+      prim.fromArrays(v, n, b, u, vc, idx, ctx)
+      mtl = lev2.PBRMaterial()
+      mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+      mtl.baseColor = vec4(1, 1, 1, 1)
+      mtl.roughnessFactor = roughness
+      mtl.metallicFactor = metallic
+      if alpha_blend:
+        mtl.alphaBlend = True
+      mtl.gpuInit(ctx)
+      self.materials.append(mtl)
+      self.prims.append(prim)
+      node = prim.createInstancedNode(count, name, self.layer1, mtl)
+      node.sortkey = 20 if alpha_blend else 10
+      return node
+
+    sphere_arrays = make_sphere_arrays(1.0, 8)
+    cube_arrays = make_cube_arrays(1.0)
 
     ##################################
     # Opaque instanced spheres
     ##################################
-    colors_opaque = np.full((nv, 4), 255, dtype=np.uint8)
+    self.sphere_node = make_instanced_set(sphere_arrays, NUM_SPHERES, "spheres", 0.4, 0.8)
+    self.sphere_instdata = self.sphere_node.instanceData
 
-    prim_opaque = RigidPrimitive()
-    prim_opaque.fromArrays(sv, sn, sb, su, colors_opaque, si, ctx)
-
-    mtl_opaque = lev2.PBRMaterial()
-    mtl_opaque.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
-    mtl_opaque.baseColor = vec4(1, 1, 1, 1)
-    mtl_opaque.roughnessFactor = 0.4
-    mtl_opaque.metallicFactor = 0.8
-    mtl_opaque.gpuInit(ctx)
-
-    self.opaque_node = prim_opaque.createInstancedNode(NUM_OPAQUE, "opaque_spheres", self.layer1, mtl_opaque)
-    self.opaque_node.sortkey = 10
-    self.opaque_instdata = self.opaque_node.instanceData
-
-    # Initialize opaque instance data
-    self.opaque_data = []
-    matrices = np.array(self.opaque_instdata.matrices, copy=False)
-    colors = np.array(self.opaque_instdata.colors, copy=False)
-    for i in range(NUM_OPAQUE):
+    self.sphere_data = []
+    matrices = np.array(self.sphere_instdata.matrices, copy=False)
+    colors = np.array(self.sphere_instdata.colors, copy=False)
+    for i in range(NUM_SPHERES):
       x = random.uniform(-10, 10)
       z = random.uniform(-10, 10)
       y = random.uniform(0.5, 5)
-      s = random.uniform(0.1, 0.4)
+      s = random.uniform(0.2, 0.5)
       phase = random.uniform(0, math.tau)
       speed = random.uniform(0.3, 1.0)
-      # Random warm color (instance tint, multiplied with vertex color)
       cr = random.uniform(0.5, 1.0)
       cg = random.uniform(0.3, 0.8)
       cb = random.uniform(0.2, 0.6)
-      self.opaque_data.append((x, y, z, s, phase, speed, cr, cg, cb))
+      self.sphere_data.append((x, y, z, s, phase, speed, cr, cg, cb))
+      m = mtx4.composed(vec3(x, y, z), quat(), s)
+      matrices[i] = np.array(m, copy=False)
+      colors[i] = (cr, cg, cb, 1.0)
+
+    ##################################
+    # Opaque instanced cubes
+    ##################################
+    self.cube_node = make_instanced_set(cube_arrays, NUM_CUBES, "cubes", 0.6, 0.5)
+    self.cube_instdata = self.cube_node.instanceData
+
+    self.cube_data = []
+    matrices = np.array(self.cube_instdata.matrices, copy=False)
+    colors = np.array(self.cube_instdata.colors, copy=False)
+    for i in range(NUM_CUBES):
+      x = random.uniform(-10, 10)
+      z = random.uniform(-10, 10)
+      y = random.uniform(0.5, 4)
+      s = random.uniform(0.15, 0.4)
+      phase = random.uniform(0, math.tau)
+      speed = random.uniform(0.2, 0.7)
+      rx_speed = random.uniform(0.3, 1.2)
+      rz_speed = random.uniform(0.2, 0.8)
+      cr = random.uniform(0.3, 0.7)
+      cg = random.uniform(0.3, 0.7)
+      cb = random.uniform(0.5, 1.0)
+      self.cube_data.append((x, y, z, s, phase, speed, rx_speed, rz_speed, cr, cg, cb))
       m = mtx4.composed(vec3(x, y, z), quat(), s)
       matrices[i] = np.array(m, copy=False)
       colors[i] = (cr, cg, cb, 1.0)
@@ -135,28 +195,9 @@ class InstancingApp(object):
     ##################################
     # Transparent instanced spheres
     ##################################
-    colors_trans = np.zeros((nv, 4), dtype=np.uint8)
-    colors_trans[:, 0] = 230
-    colors_trans[:, 1] = 240
-    colors_trans[:, 2] = 255
-    colors_trans[:, 3] = 255  # vertex alpha = 1, instance alpha controls opacity
-
-    prim_trans = RigidPrimitive()
-    prim_trans.fromArrays(sv, sn, sb, su, colors_trans, si, ctx)
-
-    mtl_trans = lev2.PBRMaterial()
-    mtl_trans.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
-    mtl_trans.baseColor = vec4(1, 1, 1, 1)
-    mtl_trans.roughnessFactor = 0.0
-    mtl_trans.metallicFactor = 1.0
-    mtl_trans.alphaBlend = True
-    mtl_trans.gpuInit(ctx)
-
-    self.trans_node = prim_trans.createInstancedNode(NUM_TRANSPARENT, "trans_spheres", self.layer1, mtl_trans)
-    self.trans_node.sortkey = 20
+    self.trans_node = make_instanced_set(sphere_arrays, NUM_TRANSPARENT, "trans_spheres", 0.0, 1.0, alpha_blend=True)
     self.trans_instdata = self.trans_node.instanceData
 
-    # Initialize transparent instance data
     self.trans_data = []
     matrices = np.array(self.trans_instdata.matrices, copy=False)
     colors = np.array(self.trans_instdata.colors, copy=False)
@@ -174,10 +215,6 @@ class InstancingApp(object):
       matrices[i] = np.array(m, copy=False)
       colors[i] = (0.9, 0.95, 1.0, 0.4)
 
-    # Keep materials alive
-    self.materials = [mtl_opaque, mtl_trans]
-    self.prims = [prim_opaque, prim_trans]
-
     # Lighting — two point lights
     self.dyn_lights = []
     for lname, lpos, lcolor, lintens in [
@@ -194,28 +231,47 @@ class InstancingApp(object):
 
     self.scene.lightingmanager.gpuInit(ctx)
 
-    print(f"Instancing Test: {NUM_OPAQUE} opaque + {NUM_TRANSPARENT} transparent spheres")
+    print(f"Instancing Test: {NUM_SPHERES} spheres + {NUM_CUBES} cubes + {NUM_TRANSPARENT} transparent bubbles")
 
   ##############################################
 
   def onGpuUpdate(self, ctx):
     t = self.time
 
-    # Animate opaque instances: gentle bobbing
-    matrices = np.array(self.opaque_instdata.matrices, copy=False)
-    for i in range(NUM_OPAQUE):
-      x, y_base, z, s, phase, speed, cr, cg, cb = self.opaque_data[i]
+    # Animate spheres: bobbing, occasional visibility toggle
+    matrices = np.array(self.sphere_instdata.matrices, copy=False)
+    colors = np.array(self.sphere_instdata.colors, copy=False)
+    for i in range(NUM_SPHERES):
+      x, y_base, z, s, phase, speed, cr, cg, cb = self.sphere_data[i]
+      # Rare visibility toggle (~5% hidden at any time)
+      visible = math.sin(t * 0.2 + phase * 3.7) > -0.9
+      if not visible:
+        matrices[i] = np.zeros((4, 4), dtype=np.float32)
+        colors[i] = (0, 0, 0, 0)
+        continue
       y = y_base + math.sin(t * speed + phase) * 0.3
       m = mtx4.composed(vec3(x, y, z), quat(vec3(0, 1, 0), t * speed + phase), s)
       matrices[i] = np.array(m, copy=False)
+      colors[i] = (cr, cg, cb, 1.0)
 
-    # Animate transparent instances: fade in/out lifecycle
+    # Animate cubes: tumbling rotation, scale pulsing
+    matrices = np.array(self.cube_instdata.matrices, copy=False)
+    colors = np.array(self.cube_instdata.colors, copy=False)
+    for i in range(NUM_CUBES):
+      x, y_base, z, s, phase, speed, rx_spd, rz_spd, cr, cg, cb = self.cube_data[i]
+      y = y_base + math.sin(t * speed + phase) * 0.2
+      pulse = s * (0.8 + 0.2 * math.sin(t * 1.5 + phase))
+      rot = quat(vec3(1, 0, 0), t * rx_spd + phase) * quat(vec3(0, 1, 0), t * speed) * quat(vec3(0, 0, 1), t * rz_spd)
+      m = mtx4.composed(vec3(x, y, z), rot, pulse)
+      matrices[i] = np.array(m, copy=False)
+      colors[i] = (cr, cg, cb, 1.0)
+
+    # Animate transparent spheres: fade in/out lifecycle
     matrices = np.array(self.trans_instdata.matrices, copy=False)
     colors = np.array(self.trans_instdata.colors, copy=False)
     for i in range(NUM_TRANSPARENT):
       x, y_base, z, s, phase, speed, birth, lifetime = self.trans_data[i]
       age = t - birth
-      # Wrap around
       cycle_age = age % lifetime
       fade = 1.0 - (cycle_age / lifetime) ** 1.5
       alpha = max(0.0, 0.5 * fade)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
@@ -96,11 +96,7 @@ class InstancingApp(object):
     ##################################
     # Opaque instanced spheres
     ##################################
-    colors_opaque = np.zeros((nv, 4), dtype=np.uint8)
-    colors_opaque[:, 0] = 200
-    colors_opaque[:, 1] = 200
-    colors_opaque[:, 2] = 200
-    colors_opaque[:, 3] = 255
+    colors_opaque = np.full((nv, 4), 255, dtype=np.uint8)
 
     prim_opaque = RigidPrimitive()
     prim_opaque.fromArrays(sv, sn, sb, su, colors_opaque, si, ctx)
@@ -108,8 +104,8 @@ class InstancingApp(object):
     mtl_opaque = lev2.PBRMaterial()
     mtl_opaque.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
     mtl_opaque.baseColor = vec4(1, 1, 1, 1)
-    mtl_opaque.roughnessFactor = 0.5
-    mtl_opaque.metallicFactor = 0.0
+    mtl_opaque.roughnessFactor = 0.4
+    mtl_opaque.metallicFactor = 0.8
     mtl_opaque.gpuInit(ctx)
 
     self.opaque_node = prim_opaque.createInstancedNode(NUM_OPAQUE, "opaque_spheres", self.layer1, mtl_opaque)
@@ -127,10 +123,10 @@ class InstancingApp(object):
       s = random.uniform(0.1, 0.4)
       phase = random.uniform(0, math.tau)
       speed = random.uniform(0.3, 1.0)
-      # Random warm color
-      cr = random.uniform(0.1, 0.25)
-      cg = random.uniform(0.05, 0.15)
-      cb = random.uniform(0.03, 0.1)
+      # Random warm color (instance tint, multiplied with vertex color)
+      cr = random.uniform(0.5, 1.0)
+      cg = random.uniform(0.3, 0.8)
+      cb = random.uniform(0.2, 0.6)
       self.opaque_data.append((x, y, z, s, phase, speed, cr, cg, cb))
       m = mtx4.composed(vec3(x, y, z), quat(), s)
       matrices[i] = np.array(m, copy=False)
@@ -182,14 +178,19 @@ class InstancingApp(object):
     self.materials = [mtl_opaque, mtl_trans]
     self.prims = [prim_opaque, prim_trans]
 
-    # Lighting
-    light = lev2.DynamicPointLight()
-    light.data.color = vec3(1, 0.95, 0.85)
-    light.data.intensity = 8.0
-    light.data.radius = 30.0
-    self.light_node = light.data.createNode("sun", self.layer1)
-    self.light_node.worldTransform.translation = vec3(5, 10, 5)
-    self.light = light
+    # Lighting — two point lights
+    self.dyn_lights = []
+    for lname, lpos, lcolor, lintens in [
+      ("key",  vec3(5, 12, 5),   vec3(1, 0.95, 0.85), 20.0),
+      ("fill", vec3(-5, 10, -3), vec3(0.5, 0.6, 0.9), 12.0),
+    ]:
+      light = lev2.DynamicPointLight()
+      light.data.color = lcolor
+      light.data.intensity = lintens
+      light.data.radius = 30.0
+      light_node = self.layer1.createLightNode(lname, light)
+      light_node.setMatrix(mtx4.transMatrix(lpos))
+      self.dyn_lights.append(light)
 
     self.scene.lightingmanager.gpuInit(ctx)
 

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py
@@ -17,7 +17,7 @@ import math, sys, signal, random
 import numpy as np
 from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
 from orkengine import lev2
-from orkengine.lev2 import RigidPrimitive
+from orkengine.lev2 import RigidPrimitive, MicroMesh
 
 lev2_pyexdir.addToSysPath()
 from lev2utils.cameras import setupUiCamera
@@ -33,6 +33,7 @@ NUM_TRANSPARENT = 200
 ################################################################################
 
 def make_sphere_arrays(radius=1.0, n=8):
+  # Faces are CCW-from-outside; MicroMesh handles winding internally.
   verts, norms = [], []
   for i in range(n + 1):
     lat = math.pi * i / n
@@ -44,14 +45,14 @@ def make_sphere_arrays(radius=1.0, n=8):
       verts.append((x * radius, y * radius, z * radius))
       norms.append((x, y, z))
   w = n * 2
-  indices = []
+  faces = []
   for i in range(n):
     for j in range(w):
       a = i * w + j
       b = a + 1 if j < w - 1 else i * w
       c = a + w
       d = c + 1 if j < w - 1 else (i + 1) * w
-      indices.extend([a, c, b, b, c, d])
+      faces.extend([3, a, b, c, 3, b, d, c])
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
@@ -61,8 +62,7 @@ def make_sphere_arrays(radius=1.0, n=8):
   binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
   lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
   binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, faces
 
 def make_cube_arrays(size=1.0):
   h = size / 2.0
@@ -74,20 +74,19 @@ def make_cube_arrays(size=1.0):
     ((0,1,0),  [(-h,h,h),(h,h,h),(h,h,-h),(-h,h,-h)]),
     ((0,-1,0), [(-h,-h,-h),(h,-h,-h),(h,-h,h),(-h,-h,h)]),
   ]
-  verts, norms, indices = [], [], []
+  verts, norms, faces = [], [], []
   for (nx, ny, nz), corners in face_data:
     base = len(verts)
     for c in corners:
       verts.append(c)
       norms.append((nx, ny, nz))
-    indices.extend([base, base+2, base+1, base, base+3, base+2])
+    faces.extend([3, base, base+1, base+2, 3, base, base+2, base+3])
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
   binormals_np = np.zeros((nv, 3), dtype=np.float32)
   binormals_np[:, 0] = 1.0
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, faces
 
 ################################################################################
 
@@ -120,11 +119,16 @@ class InstancingApp(object):
     self.prims = []
 
     def make_instanced_set(mesh_arrays, count, name, roughness, metallic, alpha_blend=False):
-      v, n, b, u, idx = mesh_arrays
+      v, n, b, faces = mesh_arrays
       nv = len(v)
-      vc = np.full((nv, 4), 255, dtype=np.uint8)
+      # White vertex colors — per-instance colors come from the SSBO modcolors.
+      vc = np.ones((nv, 4), dtype=np.float32)
+      mesh = MicroMesh.fromVertAndFaceLists(v, faces)
+      mesh.updateNormals(n)
+      mesh.updateBinormals(b)
+      mesh.updateColors(vc)
       prim = RigidPrimitive()
-      prim.fromArrays(v, n, b, u, vc, idx, ctx)
+      prim.updateWithMicroMesh(mesh, ctx, tokens.TRIANGLES)
       mtl = lev2.PBRMaterial()
       mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
       mtl.baseColor = vec4(1, 1, 1, 1)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env ork.python
+
+################################################################################
+# Procedural Geometry + Point Lights Test
+# Demonstrates DynamicPointLight with procedural PBR vertex-color geometry.
+# Multiple colored point lights orbit around a set of procedural objects
+# with varying PBR materials (matte, metallic, mirror).
+# Copyright 1996-2023, Michael T. Mayers.
+# Distributed under the MIT License
+# see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+################################################################################
+
+import math, sys, signal
+import numpy as np
+from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
+from orkengine import lev2
+from orkengine.lev2 import RigidPrimitive
+
+lev2_pyexdir.addToSysPath()
+from lev2utils.cameras import setupUiCamera
+from lev2utils.primitives import createGridData
+from lev2utils.scenegraph import createSceneGraph
+
+tokens = CrcStringProxy()
+
+################################################################################
+
+def make_sphere_arrays(radius=1.0, n=12):
+  verts, norms = [], []
+  for i in range(n + 1):
+    lat = math.pi * i / n
+    for j in range(n * 2):
+      lon = math.tau * j / (n * 2)
+      x = math.sin(lat) * math.cos(lon)
+      y = math.cos(lat)
+      z = math.sin(lat) * math.sin(lon)
+      verts.append((x * radius, y * radius, z * radius))
+      norms.append((x, y, z))
+  w = n * 2
+  indices = []
+  for i in range(n):
+    for j in range(w):
+      a = i * w + j
+      b = a + 1 if j < w - 1 else i * w
+      c = a + w
+      d = c + 1 if j < w - 1 else (i + 1) * w
+      indices.extend([a, c, b, b, c, d])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  up = np.array([0, 1, 0], dtype=np.float32)
+  binormals_np = np.cross(norms_np, up)
+  degen = np.linalg.norm(binormals_np, axis=1) < 1e-6
+  binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
+  lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
+  binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+
+################################################################################
+
+class PointLightsApp(object):
+
+  def __init__(self):
+    super().__init__()
+    self.ezapp = lev2.OrkEzApp.create(self, width=1280, height=720)
+    self.ezapp.setRefreshPolicy(lev2.RefreshFastest, 0)
+    setupUiCamera(app=self, eye=vec3(0, 4, 10), tgt=vec3(0, 1, 0))
+    signal.signal(signal.SIGINT, lambda s, f: self.ezapp.signalExit())
+    self.time = 0.0
+
+  ##############################################
+
+  def onGpuInit(self, ctx):
+    createSceneGraph(app=self)
+
+    self.grid_data = createGridData()
+    self.grid_node = self.layer1.createDrawableNodeFromData("grid", self.grid_data)
+    self.grid_node.sortkey = 1
+
+    white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.full((4, 4, 4), 255, dtype=np.uint8))
+    normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+
+    sv, sn, sb, su, si = make_sphere_arrays(1.0, 12)
+    self.materials = []
+
+    # Three spheres: matte, metallic, mirror
+    configs = [
+      ("matte",    (-2.5, 1.2, 0), (0.2, 0.15, 0.12), 0.9, 0.0),
+      ("metallic", (0,    1.2, 0), (0.7, 0.5, 0.3),   0.3, 1.0),
+      ("mirror",   (2.5,  1.2, 0), (0.9, 0.9, 0.9),   0.0, 1.0),
+    ]
+
+    for name, pos, color, roughness, metallic in configs:
+      nv = len(sv)
+      r, g, b = color
+      colors_np = np.zeros((nv, 4), dtype=np.uint8)
+      colors_np[:, 0] = int(r * 255)
+      colors_np[:, 1] = int(g * 255)
+      colors_np[:, 2] = int(b * 255)
+      colors_np[:, 3] = 255
+
+      prim = RigidPrimitive()
+      prim.fromArrays(sv, sn, sb, su, colors_np, si, ctx)
+
+      mtl = lev2.PBRMaterial()
+      mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+      mtl.baseColor = vec4(1, 1, 1, 1)
+      mtl.roughnessFactor = roughness
+      mtl.metallicFactor = metallic
+      mtl.gpuInit(ctx)
+      self.materials.append(mtl)
+
+      node = prim.createNode(name, self.layer1, mtl)
+      node.worldTransform.translation = vec3(*pos)
+      node.sortkey = 10
+
+    # Three orbiting point lights
+    light_configs = [
+      ("red",   vec3(1.0, 0.2, 0.1)),
+      ("green", vec3(0.1, 1.0, 0.2)),
+      ("blue",  vec3(0.2, 0.3, 1.0)),
+    ]
+    self.lights = []
+    for name, color in light_configs:
+      light = lev2.DynamicPointLight()
+      light.data.color = color
+      light.data.intensity = 8.0
+      light.data.radius = 15.0
+      light_node = light.data.createNode(f"light_{name}", self.layer1)
+      self.lights.append((light, light_node))
+
+    self.scene.lightingmanager.gpuInit(ctx)
+
+    print("Point Lights Test:")
+    print("  Left: matte sphere (rough=0.9, metal=0)")
+    print("  Center: metallic sphere (rough=0.3, metal=1)")
+    print("  Right: mirror sphere (rough=0, metal=1)")
+    print("  Three colored point lights orbit the scene")
+
+  ##############################################
+
+  def onGpuUpdate(self, ctx):
+    t = self.time
+    r = 4.0
+    for i, (light, node) in enumerate(self.lights):
+      angle = t * 1.2 + i * math.tau / 3
+      x = r * math.cos(angle)
+      z = r * math.sin(angle)
+      y = 2.0 + math.sin(t * 2.0 + i) * 0.5
+      node.worldTransform.translation = vec3(x, y, z)
+
+  def onUiEvent(self, uievent):
+    handled = self.uicam.uiEventHandler(uievent)
+    if handled:
+      self.camera.copyFrom(self.uicam.cameradata)
+    return lev2.ui.HandlerResult()
+
+  def onUpdate(self, updinfo):
+    self.time = updinfo.absolutetime
+    self.scene.updateScene(self.cameralut)
+
+################################################################################
+
+if __name__ == "__main__":
+  app = PointLightsApp()
+  app.ezapp.mainThreadLoop()

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
@@ -86,6 +86,7 @@ class PointLightsApp(object):
 
     sv, sn, sb, su, si = make_sphere_arrays(1.0, 12)
     self.materials = []
+    self.prims = []
 
     # Three spheres: matte, metallic, mirror
     configs = [
@@ -113,12 +114,14 @@ class PointLightsApp(object):
       mtl.metallicFactor = metallic
       mtl.gpuInit(ctx)
       self.materials.append(mtl)
+      self.prims.append(prim)
 
       node = prim.createNode(name, self.layer1, mtl)
       node.worldTransform.translation = vec3(*pos)
       node.sortkey = 10
 
-    # Three orbiting point lights
+    # Three orbiting point lights with indicator spheres
+    orb_sv, orb_sn, orb_sb, orb_su, orb_si = make_sphere_arrays(0.12, 6)
     light_configs = [
       ("red",   vec3(1.0, 0.2, 0.1)),
       ("green", vec3(0.1, 1.0, 0.2)),
@@ -130,8 +133,28 @@ class PointLightsApp(object):
       light.data.color = color
       light.data.intensity = 8.0
       light.data.radius = 15.0
-      light_node = light.data.createNode(f"light_{name}", self.layer1)
-      self.lights.append((light, light_node))
+      light_node = self.layer1.createLightNode(f"light_{name}", light)
+
+      # Indicator sphere matching light color
+      nv = len(orb_sv)
+      orb_colors = np.zeros((nv, 4), dtype=np.uint8)
+      orb_colors[:, 0] = int(min(color.x, 1.0) * 255)
+      orb_colors[:, 1] = int(min(color.y, 1.0) * 255)
+      orb_colors[:, 2] = int(min(color.z, 1.0) * 255)
+      orb_colors[:, 3] = 255
+      orb_prim = RigidPrimitive()
+      orb_prim.fromArrays(orb_sv, orb_sn, orb_sb, orb_su, orb_colors, orb_si, ctx)
+      orb_mtl = lev2.PBRMaterial()
+      orb_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+      orb_mtl.baseColor = vec4(1, 1, 1, 1)
+      orb_mtl.roughnessFactor = 0.0
+      orb_mtl.metallicFactor = 0.0
+      orb_mtl.gpuInit(ctx)
+      self.materials.append(orb_mtl)
+      self.prims.append(orb_prim)
+      orb_node = orb_prim.createNode(f"orb_{name}", self.layer1, orb_mtl)
+
+      self.lights.append((light, light_node, orb_node))
 
     self.scene.lightingmanager.gpuInit(ctx)
 
@@ -139,19 +162,20 @@ class PointLightsApp(object):
     print("  Left: matte sphere (rough=0.9, metal=0)")
     print("  Center: metallic sphere (rough=0.3, metal=1)")
     print("  Right: mirror sphere (rough=0, metal=1)")
-    print("  Three colored point lights orbit the scene")
+    print("  Three colored point lights orbit in an ellipse")
 
   ##############################################
 
   def onGpuUpdate(self, ctx):
     t = self.time
-    r = 4.0
-    for i, (light, node) in enumerate(self.lights):
-      angle = t * 1.2 + i * math.tau / 3
-      x = r * math.cos(angle)
-      z = r * math.sin(angle)
-      y = 2.0 + math.sin(t * 2.0 + i) * 0.5
-      node.worldTransform.translation = vec3(x, y, z)
+    rx, rz = 5.0, 3.0  # ellipse radii
+    for i, (light, light_node, orb_node) in enumerate(self.lights):
+      angle = t * 0.8 + i * math.tau / 3
+      x = rx * math.cos(angle)
+      z = rz * math.sin(angle)
+      y = 2.0 + math.sin(t * 1.5 + i) * 0.8
+      light_node.setMatrix(mtx4.transMatrix(vec3(x, y, z)))
+      orb_node.worldTransform.translation = vec3(x, y, z)
 
   def onUiEvent(self, uievent):
     handled = self.uicam.uiEventHandler(uievent)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
@@ -72,16 +72,17 @@ class PointLightsApp(object):
   ##############################################
 
   def onGpuInit(self, ctx):
-    createSceneGraph(app=self)
+    createSceneGraph(app=self, params_dict={
+      "SkyboxTexPathStr": "ork_envmaps|cold4k",
+      "SkyboxIntensity": float(1),
+    })
 
     self.grid_data = createGridData()
     self.grid_node = self.layer1.createDrawableNodeFromData("grid", self.grid_data)
     self.grid_node.sortkey = 1
 
-    white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.full((4, 4, 4), 255, dtype=np.uint8))
-    normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+    white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
+    normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
     sv, sn, sb, su, si = make_sphere_arrays(1.0, 12)
     self.materials = []

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
@@ -14,7 +14,7 @@ import math, sys, signal
 import numpy as np
 from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
 from orkengine import lev2
-from orkengine.lev2 import RigidPrimitive
+from orkengine.lev2 import RigidPrimitive, MicroMesh
 
 lev2_pyexdir.addToSysPath()
 from lev2utils.cameras import setupUiCamera
@@ -26,6 +26,7 @@ tokens = CrcStringProxy()
 ################################################################################
 
 def make_sphere_arrays(radius=1.0, n=12):
+  # Faces are CCW-from-outside; MicroMesh handles winding internally.
   verts, norms = [], []
   for i in range(n + 1):
     lat = math.pi * i / n
@@ -37,14 +38,14 @@ def make_sphere_arrays(radius=1.0, n=12):
       verts.append((x * radius, y * radius, z * radius))
       norms.append((x, y, z))
   w = n * 2
-  indices = []
+  faces = []
   for i in range(n):
     for j in range(w):
       a = i * w + j
       b = a + 1 if j < w - 1 else i * w
       c = a + w
       d = c + 1 if j < w - 1 else (i + 1) * w
-      indices.extend([a, c, b, b, c, d])
+      faces.extend([3, a, b, c, 3, b, d, c])
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
@@ -54,8 +55,7 @@ def make_sphere_arrays(radius=1.0, n=12):
   binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
   lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
   binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  return verts_np, norms_np, binormals_np, uvs_np, np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, faces
 
 ################################################################################
 
@@ -84,7 +84,32 @@ class PointLightsApp(object):
     white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
     normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
-    sv, sn, sb, su, si = make_sphere_arrays(1.0, 12)
+    def make_solid_color_prim(verts, norms, binormals, faces, color, alpha):
+      n = len(verts)
+      # BGRA pre-swap — see vtxcolor_materials.py for the rationale.
+      colors = np.tile(np.array([color[2], color[1], color[0], alpha],
+                                dtype=np.float32), (n, 1))
+      mesh = MicroMesh.fromVertAndFaceLists(verts, faces)
+      mesh.updateNormals(norms)
+      mesh.updateBinormals(binormals)
+      mesh.updateColors(colors)
+      prim = RigidPrimitive()
+      prim.updateWithMicroMesh(mesh, ctx, tokens.TRIANGLES)
+      return prim
+
+    def make_pbr_material(roughness, metallic, alpha_blend):
+      mtl = lev2.PBRMaterial()
+      mtl.assignImages(ctx, color=white_img, normal=normal_img,
+                       mtlruf=white_img, doConform=True)
+      mtl.baseColor = vec4(1, 1, 1, 1)
+      mtl.roughnessFactor = roughness
+      mtl.metallicFactor = metallic
+      if alpha_blend:
+        mtl.alphaBlend = True
+      mtl.gpuInit(ctx)
+      return mtl
+
+    sv, sn, sb, sf = make_sphere_arrays(1.0, 12)
     self.materials = []
     self.prims = []
 
@@ -97,34 +122,17 @@ class PointLightsApp(object):
     ]
 
     for name, pos, color, roughness, metallic, alpha_blend in configs:
-      nv = len(sv)
-      r, g, b = color
-      colors_np = np.zeros((nv, 4), dtype=np.uint8)
-      colors_np[:, 0] = int(r * 255)
-      colors_np[:, 1] = int(g * 255)
-      colors_np[:, 2] = int(b * 255)
-      colors_np[:, 3] = 76 if alpha_blend else 255
-
-      prim = RigidPrimitive()
-      prim.fromArrays(sv, sn, sb, su, colors_np, si, ctx)
-
-      mtl = lev2.PBRMaterial()
-      mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
-      mtl.baseColor = vec4(1, 1, 1, 1)
-      mtl.roughnessFactor = roughness
-      mtl.metallicFactor = metallic
-      if alpha_blend:
-        mtl.alphaBlend = True
-      mtl.gpuInit(ctx)
+      alpha = 0.3 if alpha_blend else 1.0
+      prim = make_solid_color_prim(sv, sn, sb, sf, color, alpha)
+      mtl = make_pbr_material(roughness, metallic, alpha_blend)
       self.materials.append(mtl)
       self.prims.append(prim)
-
       node = prim.createNode(name, self.layer1, mtl)
       node.worldTransform.translation = vec3(*pos)
       node.sortkey = 20 if alpha_blend else 10
 
     # Three orbiting point lights with indicator spheres
-    orb_sv, orb_sn, orb_sb, orb_su, orb_si = make_sphere_arrays(0.12, 6)
+    orb_sv, orb_sn, orb_sb, orb_sf = make_sphere_arrays(0.12, 6)
     light_configs = [
       ("red",   vec3(1.0, 0.2, 0.1)),
       ("green", vec3(0.1, 1.0, 0.2)),
@@ -138,21 +146,9 @@ class PointLightsApp(object):
       light.data.radius = 15.0
       light_node = self.layer1.createLightNode(f"light_{name}", light)
 
-      # Indicator sphere matching light color
-      nv = len(orb_sv)
-      orb_colors = np.zeros((nv, 4), dtype=np.uint8)
-      orb_colors[:, 0] = int(min(color.x, 1.0) * 255)
-      orb_colors[:, 1] = int(min(color.y, 1.0) * 255)
-      orb_colors[:, 2] = int(min(color.z, 1.0) * 255)
-      orb_colors[:, 3] = 255
-      orb_prim = RigidPrimitive()
-      orb_prim.fromArrays(orb_sv, orb_sn, orb_sb, orb_su, orb_colors, orb_si, ctx)
-      orb_mtl = lev2.PBRMaterial()
-      orb_mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
-      orb_mtl.baseColor = vec4(1, 1, 1, 1)
-      orb_mtl.roughnessFactor = 0.0
-      orb_mtl.metallicFactor = 0.0
-      orb_mtl.gpuInit(ctx)
+      orb_color = (min(color.x, 1.0), min(color.y, 1.0), min(color.z, 1.0))
+      orb_prim = make_solid_color_prim(orb_sv, orb_sn, orb_sb, orb_sf, orb_color, 1.0)
+      orb_mtl = make_pbr_material(0.0, 0.0, False)
       self.materials.append(orb_mtl)
       self.prims.append(orb_prim)
       orb_node = orb_prim.createNode(f"orb_{name}", self.layer1, orb_mtl)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py
@@ -90,19 +90,20 @@ class PointLightsApp(object):
 
     # Three spheres: matte, metallic, mirror
     configs = [
-      ("matte",    (-2.5, 1.2, 0), (0.2, 0.15, 0.12), 0.9, 0.0),
-      ("metallic", (0,    1.2, 0), (0.7, 0.5, 0.3),   0.3, 1.0),
-      ("mirror",   (2.5,  1.2, 0), (0.9, 0.9, 0.9),   0.0, 1.0),
+      ("matte",    (-3.75, 1.2, 0), (0.6, 0.55, 0.5),  0.9, 0.0, False),
+      ("metallic", (-1.25, 1.2, 0), (0.7, 0.5, 0.3),  0.3, 1.0, False),
+      ("mirror",   (1.25,  1.2, 0), (0.9, 0.9, 0.9),  0.0, 1.0, False),
+      ("glass",    (3.75,  1.2, 0), (0.9, 0.95, 1.0),  0.0, 1.0, True),
     ]
 
-    for name, pos, color, roughness, metallic in configs:
+    for name, pos, color, roughness, metallic, alpha_blend in configs:
       nv = len(sv)
       r, g, b = color
       colors_np = np.zeros((nv, 4), dtype=np.uint8)
       colors_np[:, 0] = int(r * 255)
       colors_np[:, 1] = int(g * 255)
       colors_np[:, 2] = int(b * 255)
-      colors_np[:, 3] = 255
+      colors_np[:, 3] = 76 if alpha_blend else 255
 
       prim = RigidPrimitive()
       prim.fromArrays(sv, sn, sb, su, colors_np, si, ctx)
@@ -112,13 +113,15 @@ class PointLightsApp(object):
       mtl.baseColor = vec4(1, 1, 1, 1)
       mtl.roughnessFactor = roughness
       mtl.metallicFactor = metallic
+      if alpha_blend:
+        mtl.alphaBlend = True
       mtl.gpuInit(ctx)
       self.materials.append(mtl)
       self.prims.append(prim)
 
       node = prim.createNode(name, self.layer1, mtl)
       node.worldTransform.translation = vec3(*pos)
-      node.sortkey = 10
+      node.sortkey = 20 if alpha_blend else 10
 
     # Three orbiting point lights with indicator spheres
     orb_sv, orb_sn, orb_sb, orb_su, orb_si = make_sphere_arrays(0.12, 6)
@@ -159,16 +162,17 @@ class PointLightsApp(object):
     self.scene.lightingmanager.gpuInit(ctx)
 
     print("Point Lights Test:")
-    print("  Left: matte sphere (rough=0.9, metal=0)")
-    print("  Center: metallic sphere (rough=0.3, metal=1)")
-    print("  Right: mirror sphere (rough=0, metal=1)")
+    print("  matte sphere (rough=0.9, metal=0)")
+    print("  metallic sphere (rough=0.3, metal=1)")
+    print("  mirror sphere (rough=0, metal=1)")
+    print("  glass sphere (rough=0, metal=1, transparent)")
     print("  Three colored point lights orbit in an ellipse")
 
   ##############################################
 
   def onGpuUpdate(self, ctx):
     t = self.time
-    rx, rz = 5.0, 3.0  # ellipse radii
+    rx, rz = 6.0, 3.5  # ellipse radii
     for i, (light, light_node, orb_node) in enumerate(self.lights):
       angle = t * 0.8 + i * math.tau / 3
       x = rx * math.cos(angle)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
@@ -16,7 +16,7 @@ import math, sys, signal
 import numpy as np
 from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
 from orkengine import lev2
-from orkengine.lev2 import RigidPrimitive
+from orkengine.lev2 import RigidPrimitive, MicroMesh
 
 lev2_pyexdir.addToSysPath()
 from lev2utils.cameras import setupUiCamera
@@ -28,6 +28,7 @@ tokens = CrcStringProxy()
 ################################################################################
 
 def make_sphere_arrays(radius=1.0, n=12):
+  # Faces are CCW-from-outside; MicroMesh handles winding internally.
   verts = []
   norms = []
   for i in range(n + 1):
@@ -40,14 +41,14 @@ def make_sphere_arrays(radius=1.0, n=12):
       verts.append((x * radius, y * radius, z * radius))
       norms.append((x, y, z))
   w = n * 2
-  indices = []
+  faces = []
   for i in range(n):
     for j in range(w):
       a = i * w + j
       b = a + 1 if j < w - 1 else i * w
       c = a + w
       d = c + 1 if j < w - 1 else (i + 1) * w
-      indices.extend([a, c, b, b, c, d])
+      faces.extend([3, a, b, c, 3, b, d, c])
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
@@ -57,14 +58,11 @@ def make_sphere_arrays(radius=1.0, n=12):
   binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
   lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
   binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  indices_np = np.array(indices, dtype=np.uint32)
-  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+  return verts_np, norms_np, binormals_np, faces
 
 def make_cube_arrays(size=1.0):
   h = size / 2.0
   face_data = [
-    # (normal, vertices) per face
     ((0,0,1),  [(-h,-h,h),(h,-h,h),(h,h,h),(-h,h,h)]),
     ((0,0,-1), [(h,-h,-h),(-h,-h,-h),(-h,h,-h),(h,h,-h)]),
     ((1,0,0),  [(h,-h,h),(h,-h,-h),(h,h,-h),(h,h,h)]),
@@ -74,35 +72,34 @@ def make_cube_arrays(size=1.0):
   ]
   verts = []
   norms = []
-  indices = []
+  faces = []
   for (nx, ny, nz), corners in face_data:
     base = len(verts)
     for c in corners:
       verts.append(c)
       norms.append((nx, ny, nz))
-    indices.extend([base, base+2, base+1, base, base+3, base+2])
+    faces.extend([3, base, base+1, base+2, 3, base, base+2, base+3])
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
   binormals_np = np.zeros((nv, 3), dtype=np.float32)
   binormals_np[:, 0] = 1.0
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  indices_np = np.array(indices, dtype=np.uint32)
-  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+  return verts_np, norms_np, binormals_np, faces
 
 ################################################################################
 
-def create_prim(ctx, verts, norms, binormals, uvs, indices, color, alpha, roughness, metallic, alpha_blend, white_img, normal_img):
+def create_prim(ctx, verts, norms, binormals, faces, color, alpha, roughness, metallic, alpha_blend, white_img, normal_img):
   nv = len(verts)
   r, g, b = color
-  colors_np = np.zeros((nv, 4), dtype=np.uint8)
-  colors_np[:, 0] = int(r * 255)
-  colors_np[:, 1] = int(g * 255)
-  colors_np[:, 2] = int(b * 255)
-  colors_np[:, 3] = int(alpha * 255)
+  # BGRA pre-swap — see vtxcolor_materials.py for the rationale.
+  colors_np = np.tile(np.array([b, g, r, alpha], dtype=np.float32), (nv, 1))
 
+  mesh = MicroMesh.fromVertAndFaceLists(verts, faces)
+  mesh.updateNormals(norms)
+  mesh.updateBinormals(binormals)
+  mesh.updateColors(colors_np)
   prim = RigidPrimitive()
-  prim.fromArrays(verts, norms, binormals, uvs, colors_np, indices, ctx)
+  prim.updateWithMicroMesh(mesh, ctx, tokens.TRIANGLES)
 
   mtl = lev2.PBRMaterial()
   mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
@@ -141,14 +138,14 @@ class TransparencyApp(object):
     self.white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
     self.normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
-    sv, sn, sb, su, si = make_sphere_arrays(radius=1.0, n=12)
-    cv, cn, cb, cu, ci = make_cube_arrays(size=0.8)
+    sv, sn, sb, sf = make_sphere_arrays(radius=1.0, n=12)
+    cv, cn, cb, cf = make_cube_arrays(size=0.8)
 
     self.materials = []
     self.prims = []
 
     # Center: opaque red cube
-    prim, mtl = create_prim(ctx, cv, cn, cb, cu, ci,
+    prim, mtl = create_prim(ctx, cv, cn, cb, cf,
       (0.7, 0.1, 0.05), 1.0, 0.5, 0.0, False, self.white_img, self.normal_img)
     self.materials.append(mtl)
     self.prims.append(prim)
@@ -157,7 +154,7 @@ class TransparencyApp(object):
     self.cube_node.sortkey = 10
 
     # Left: transparent blue sphere (fixed alpha 0.35)
-    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+    prim, mtl = create_prim(ctx, sv, sn, sb, sf,
       (0.6, 0.7, 1.0), 0.35, 0.0, 1.0, True, self.white_img, self.normal_img)
     self.materials.append(mtl)
     self.prims.append(prim)
@@ -166,7 +163,7 @@ class TransparencyApp(object):
     self.sphere_fixed.sortkey = 20
 
     # Center: transparent sphere around the cube (mirror + transparent)
-    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+    prim, mtl = create_prim(ctx, sv, sn, sb, sf,
       (0.85, 0.9, 1.0), 0.3, 0.0, 1.0, True, self.white_img, self.normal_img)
     self.materials.append(mtl)
     self.prims.append(prim)
@@ -176,7 +173,7 @@ class TransparencyApp(object):
     self.sphere_around.sortkey = 20
 
     # Right: sphere with time-varying opacity via ModColor.a
-    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+    prim, mtl = create_prim(ctx, sv, sn, sb, sf,
       (0.9, 0.3, 0.1), 1.0, 0.3, 0.0, True, self.white_img, self.normal_img)
     self.materials.append(mtl)
     self.prims.append(prim)
@@ -185,7 +182,7 @@ class TransparencyApp(object):
     self.sphere_fading.sortkey = 20
 
     # Tint test: opaque sphere with animated tint via ModColor.rgb
-    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+    prim, mtl = create_prim(ctx, sv, sn, sb, sf,
       (0.8, 0.8, 0.8), 1.0, 0.5, 0.0, False, self.white_img, self.normal_img)
     self.materials.append(mtl)
     self.prims.append(prim)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
@@ -72,11 +72,6 @@ def make_cube_arrays(size=1.0):
     ((0,1,0),  [(-h,h,h),(h,h,h),(h,h,-h),(-h,h,-h)]),
     ((0,-1,0), [(-h,-h,-h),(h,-h,-h),(h,-h,h),(-h,-h,h)]),
   ]
-  verts, norms = [], []
-  indices = []
-  for nx, ny, nz in [(n, v) for n, v in face_data]:
-    pass
-  # Simpler: use shared verts
   verts = []
   norms = []
   indices = []
@@ -150,11 +145,13 @@ class TransparencyApp(object):
     cv, cn, cb, cu, ci = make_cube_arrays(size=0.8)
 
     self.materials = []
+    self.prims = []
 
     # Center: opaque red cube
     prim, mtl = create_prim(ctx, cv, cn, cb, cu, ci,
       (0.7, 0.1, 0.05), 1.0, 0.5, 0.0, False, self.white_img, self.normal_img)
     self.materials.append(mtl)
+    self.prims.append(prim)
     self.cube_node = prim.createNode("cube", self.layer1, mtl)
     self.cube_node.worldTransform.translation = vec3(0, 1.2, 0)
     self.cube_node.sortkey = 10
@@ -163,6 +160,7 @@ class TransparencyApp(object):
     prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
       (0.6, 0.7, 1.0), 0.35, 0.0, 1.0, True, self.white_img, self.normal_img)
     self.materials.append(mtl)
+    self.prims.append(prim)
     self.sphere_fixed = prim.createNode("sphere_fixed", self.layer1, mtl)
     self.sphere_fixed.worldTransform.translation = vec3(-3, 1.5, 0)
     self.sphere_fixed.sortkey = 20
@@ -171,6 +169,7 @@ class TransparencyApp(object):
     prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
       (0.85, 0.9, 1.0), 0.3, 0.0, 1.0, True, self.white_img, self.normal_img)
     self.materials.append(mtl)
+    self.prims.append(prim)
     self.sphere_around = prim.createNode("sphere_around", self.layer1, mtl)
     self.sphere_around.worldTransform.translation = vec3(0, 1.5, 0)
     self.sphere_around.worldTransform.scale = 1.8
@@ -180,6 +179,7 @@ class TransparencyApp(object):
     prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
       (0.9, 0.3, 0.1), 1.0, 0.3, 0.0, True, self.white_img, self.normal_img)
     self.materials.append(mtl)
+    self.prims.append(prim)
     self.sphere_fading = prim.createNode("sphere_fading", self.layer1, mtl)
     self.sphere_fading.worldTransform.translation = vec3(3, 1.5, 0)
     self.sphere_fading.sortkey = 20
@@ -188,6 +188,7 @@ class TransparencyApp(object):
     prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
       (0.8, 0.8, 0.8), 1.0, 0.5, 0.0, False, self.white_img, self.normal_img)
     self.materials.append(mtl)
+    self.prims.append(prim)
     self.sphere_tint = prim.createNode("sphere_tint", self.layer1, mtl)
     self.sphere_tint.worldTransform.translation = vec3(0, 1.5, -3)
     self.sphere_tint.sortkey = 10

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
@@ -134,16 +134,17 @@ class TransparencyApp(object):
   ##############################################
 
   def onGpuInit(self, ctx):
-    createSceneGraph(app=self)
+    createSceneGraph(app=self, params_dict={
+      "SkyboxTexPathStr": "ork_envmaps|cold4k",
+      "SkyboxIntensity": float(1),
+    })
 
     self.grid_data = createGridData()
     self.grid_node = self.layer1.createDrawableNodeFromData("grid", self.grid_data)
     self.grid_node.sortkey = 1
 
-    self.white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.full((4, 4, 4), 255, dtype=np.uint8))
-    self.normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+    self.white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
+    self.normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
     sv, sn, sb, su, si = make_sphere_arrays(radius=1.0, n=12)
     cv, cn, cb, cu, ci = make_cube_arrays(size=0.8)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env ork.python
+
+################################################################################
+# Procedural Transparency Test
+# Demonstrates alpha blending with PBR vertex-color technique:
+# - Opaque vs transparent objects (depth writes, sort keys)
+# - Per-object opacity via ModColor.a (node.modcolor)
+# - Time-varying opacity animation
+# - Transparent objects around opaque objects
+# Copyright 1996-2023, Michael T. Mayers.
+# Distributed under the MIT License
+# see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+################################################################################
+
+import math, sys, signal
+import numpy as np
+from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
+from orkengine import lev2
+from orkengine.lev2 import RigidPrimitive
+
+lev2_pyexdir.addToSysPath()
+from lev2utils.cameras import setupUiCamera
+from lev2utils.primitives import createGridData
+from lev2utils.scenegraph import createSceneGraph
+
+tokens = CrcStringProxy()
+
+################################################################################
+
+def make_sphere_arrays(radius=1.0, n=12):
+  verts = []
+  norms = []
+  for i in range(n + 1):
+    lat = math.pi * i / n
+    for j in range(n * 2):
+      lon = math.tau * j / (n * 2)
+      x = math.sin(lat) * math.cos(lon)
+      y = math.cos(lat)
+      z = math.sin(lat) * math.sin(lon)
+      verts.append((x * radius, y * radius, z * radius))
+      norms.append((x, y, z))
+  w = n * 2
+  indices = []
+  for i in range(n):
+    for j in range(w):
+      a = i * w + j
+      b = a + 1 if j < w - 1 else i * w
+      c = a + w
+      d = c + 1 if j < w - 1 else (i + 1) * w
+      indices.extend([a, c, b, b, c, d])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  up = np.array([0, 1, 0], dtype=np.float32)
+  binormals_np = np.cross(norms_np, up)
+  degen = np.linalg.norm(binormals_np, axis=1) < 1e-6
+  binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
+  lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
+  binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  indices_np = np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+
+def make_cube_arrays(size=1.0):
+  h = size / 2.0
+  face_data = [
+    # (normal, vertices) per face
+    ((0,0,1),  [(-h,-h,h),(h,-h,h),(h,h,h),(-h,h,h)]),
+    ((0,0,-1), [(h,-h,-h),(-h,-h,-h),(-h,h,-h),(h,h,-h)]),
+    ((1,0,0),  [(h,-h,h),(h,-h,-h),(h,h,-h),(h,h,h)]),
+    ((-1,0,0), [(-h,-h,-h),(-h,-h,h),(-h,h,h),(-h,h,-h)]),
+    ((0,1,0),  [(-h,h,h),(h,h,h),(h,h,-h),(-h,h,-h)]),
+    ((0,-1,0), [(-h,-h,-h),(h,-h,-h),(h,-h,h),(-h,-h,h)]),
+  ]
+  verts, norms = [], []
+  indices = []
+  for nx, ny, nz in [(n, v) for n, v in face_data]:
+    pass
+  # Simpler: use shared verts
+  verts = []
+  norms = []
+  indices = []
+  for (nx, ny, nz), corners in face_data:
+    base = len(verts)
+    for c in corners:
+      verts.append(c)
+      norms.append((nx, ny, nz))
+    indices.extend([base, base+2, base+1, base, base+3, base+2])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  binormals_np = np.zeros((nv, 3), dtype=np.float32)
+  binormals_np[:, 0] = 1.0
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  indices_np = np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+
+################################################################################
+
+def create_prim(ctx, verts, norms, binormals, uvs, indices, color, alpha, roughness, metallic, alpha_blend, white_img, normal_img):
+  nv = len(verts)
+  r, g, b = color
+  colors_np = np.zeros((nv, 4), dtype=np.uint8)
+  colors_np[:, 0] = int(r * 255)
+  colors_np[:, 1] = int(g * 255)
+  colors_np[:, 2] = int(b * 255)
+  colors_np[:, 3] = int(alpha * 255)
+
+  prim = RigidPrimitive()
+  prim.fromArrays(verts, norms, binormals, uvs, colors_np, indices, ctx)
+
+  mtl = lev2.PBRMaterial()
+  mtl.assignImages(ctx, color=white_img, normal=normal_img, mtlruf=white_img, doConform=True)
+  mtl.baseColor = vec4(1, 1, 1, 1)
+  mtl.roughnessFactor = roughness
+  mtl.metallicFactor = metallic
+  if alpha_blend:
+    mtl.alphaBlend = True
+  mtl.gpuInit(ctx)
+  return prim, mtl
+
+################################################################################
+
+class TransparencyApp(object):
+
+  def __init__(self):
+    super().__init__()
+    self.ezapp = lev2.OrkEzApp.create(self, width=1280, height=720)
+    self.ezapp.setRefreshPolicy(lev2.RefreshFastest, 0)
+    setupUiCamera(app=self, eye=vec3(0, 3, 8), tgt=vec3(0, 1.5, 0))
+    signal.signal(signal.SIGINT, lambda s, f: self.ezapp.signalExit())
+    self.time = 0.0
+
+  ##############################################
+
+  def onGpuInit(self, ctx):
+    createSceneGraph(app=self)
+
+    self.grid_data = createGridData()
+    self.grid_node = self.layer1.createDrawableNodeFromData("grid", self.grid_data)
+    self.grid_node.sortkey = 1
+
+    self.white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.full((4, 4, 4), 255, dtype=np.uint8))
+    self.normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+
+    sv, sn, sb, su, si = make_sphere_arrays(radius=1.0, n=12)
+    cv, cn, cb, cu, ci = make_cube_arrays(size=0.8)
+
+    self.materials = []
+
+    # Center: opaque red cube
+    prim, mtl = create_prim(ctx, cv, cn, cb, cu, ci,
+      (0.7, 0.1, 0.05), 1.0, 0.5, 0.0, False, self.white_img, self.normal_img)
+    self.materials.append(mtl)
+    self.cube_node = prim.createNode("cube", self.layer1, mtl)
+    self.cube_node.worldTransform.translation = vec3(0, 1.2, 0)
+    self.cube_node.sortkey = 10
+
+    # Left: transparent blue sphere (fixed alpha 0.35)
+    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+      (0.6, 0.7, 1.0), 0.35, 0.0, 1.0, True, self.white_img, self.normal_img)
+    self.materials.append(mtl)
+    self.sphere_fixed = prim.createNode("sphere_fixed", self.layer1, mtl)
+    self.sphere_fixed.worldTransform.translation = vec3(-3, 1.5, 0)
+    self.sphere_fixed.sortkey = 20
+
+    # Center: transparent sphere around the cube (mirror + transparent)
+    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+      (0.85, 0.9, 1.0), 0.3, 0.0, 1.0, True, self.white_img, self.normal_img)
+    self.materials.append(mtl)
+    self.sphere_around = prim.createNode("sphere_around", self.layer1, mtl)
+    self.sphere_around.worldTransform.translation = vec3(0, 1.5, 0)
+    self.sphere_around.worldTransform.scale = 1.8
+    self.sphere_around.sortkey = 20
+
+    # Right: sphere with time-varying opacity via ModColor.a
+    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+      (0.9, 0.3, 0.1), 1.0, 0.3, 0.0, True, self.white_img, self.normal_img)
+    self.materials.append(mtl)
+    self.sphere_fading = prim.createNode("sphere_fading", self.layer1, mtl)
+    self.sphere_fading.worldTransform.translation = vec3(3, 1.5, 0)
+    self.sphere_fading.sortkey = 20
+
+    # Tint test: opaque sphere with animated tint via ModColor.rgb
+    prim, mtl = create_prim(ctx, sv, sn, sb, su, si,
+      (0.8, 0.8, 0.8), 1.0, 0.5, 0.0, False, self.white_img, self.normal_img)
+    self.materials.append(mtl)
+    self.sphere_tint = prim.createNode("sphere_tint", self.layer1, mtl)
+    self.sphere_tint.worldTransform.translation = vec3(0, 1.5, -3)
+    self.sphere_tint.sortkey = 10
+
+    # Lighting
+    self.point_light = lev2.DynamicPointLight()
+    self.point_light.data.color = vec3(1, 0.95, 0.85)
+    self.point_light.data.intensity = 5.0
+    self.point_light.data.radius = 25.0
+    self.light_node = self.point_light.data.createNode("key", self.layer1)
+    self.light_node.worldTransform.translation = vec3(3, 5, 5)
+
+    self.scene.lightingmanager.gpuInit(ctx)
+
+    print("Transparency Test:")
+    print("  Left: fixed alpha (0.35) transparent mirror sphere")
+    print("  Center: opaque cube inside transparent sphere")
+    print("  Right: time-varying opacity (sin(t))")
+    print("  Back: animated tint via ModColor.rgb")
+
+  ##############################################
+
+  def onGpuUpdate(self, ctx):
+    t = self.time
+
+    # Animate opacity on right sphere via ModColor.a
+    opacity = 0.5 + 0.5 * math.sin(t * 1.5)
+    self.sphere_fading.modcolor = vec4(1, 1, 1, opacity)
+
+    # Animate tint on back sphere via ModColor.rgb
+    r = 0.5 + 0.5 * math.sin(t * 0.7)
+    g = 0.5 + 0.5 * math.sin(t * 0.7 + math.tau / 3)
+    b = 0.5 + 0.5 * math.sin(t * 0.7 + 2 * math.tau / 3)
+    self.sphere_tint.modcolor = vec4(r, g, b, 1.0)
+
+    # Rotate the cube
+    self.cube_node.worldTransform.orientation = quat(vec3(0, 1, 0), t * 0.5)
+
+  def onUiEvent(self, uievent):
+    handled = self.uicam.uiEventHandler(uievent)
+    if handled:
+      self.camera.copyFrom(self.uicam.cameradata)
+    return lev2.ui.HandlerResult()
+
+  def onUpdate(self, updinfo):
+    self.time = updinfo.absolutetime
+    self.scene.updateScene(self.cameralut)
+
+################################################################################
+
+if __name__ == "__main__":
+  app = TransparencyApp()
+  app.ezapp.mainThreadLoop()

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py
@@ -198,8 +198,8 @@ class TransparencyApp(object):
     self.point_light.data.color = vec3(1, 0.95, 0.85)
     self.point_light.data.intensity = 5.0
     self.point_light.data.radius = 25.0
-    self.light_node = self.point_light.data.createNode("key", self.layer1)
-    self.light_node.worldTransform.translation = vec3(3, 5, 5)
+    self.light_node = self.layer1.createLightNode("key", self.point_light)
+    self.light_node.setMatrix(mtx4.transMatrix(vec3(3, 5, 5)))
 
     self.scene.lightingmanager.gpuInit(ctx)
 

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
@@ -76,8 +76,9 @@ MATERIALS = [
   ("chalk",    (0.8, 0.75, 0.7), 1.0, 0.0, False),
   ("obsidian", (0.05, 0.05, 0.06), 0.1, 0.0, False),
   ("copper",   (0.7, 0.4, 0.2),  0.2, 1.0, False),
-  ("plastic",  (0.6, 0.1, 0.1),  0.3, 0.0, False),
+  ("plastic",  (0.6, 0.1, 0.1),  0.15, 0.8, False),
   ("glass",    (0.9, 0.95, 1.0), 0.0, 0.0, True),
+  ("bubble",   (0.9, 0.95, 1.0), 0.0, 1.0, True),
 ]
 
 ################################################################################
@@ -95,7 +96,10 @@ class ProceduralMaterialsApp(object):
   ##############################################
 
   def onGpuInit(self, ctx):
-    createSceneGraph(app=self)
+    createSceneGraph(app=self, params_dict={
+      "SkyboxTexPathStr": "ork_envmaps|cold4k",
+      "SkyboxIntensity": float(1),
+    })
 
     # Grid
     self.grid_data = createGridData()
@@ -103,10 +107,8 @@ class ProceduralMaterialsApp(object):
     self.grid_node.sortkey = 1
 
     # White textures for PBR (vertex colors provide albedo)
-    self.white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.full((4, 4, 4), 255, dtype=np.uint8))
-    self.normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
-      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+    self.white_img = lev2.Image.createFromFile("src://effect_textures/white.dds")
+    self.normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
     # Sphere mesh data (shared across all materials)
     verts_np, norms_np, binormals_np, uvs_np, indices_np = make_sphere_arrays(radius=1.0, n=16)

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
@@ -2,7 +2,7 @@
 
 ################################################################################
 # Procedural PBR Materials Test
-# Demonstrates RigidPrimitive.fromArrays with PBR vertex-color technique,
+# Demonstrates MicroMesh + RigidPrimitive with PBR vertex-color technique,
 # per-object roughness/metallic via PBRMaterial, and ModColor tint/opacity.
 # Renders a row of spheres with different PBR material properties.
 # Copyright 1996-2023, Michael T. Mayers.
@@ -14,7 +14,7 @@ import math, sys, signal
 import numpy as np
 from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
 from orkengine import lev2
-from orkengine.lev2 import RigidPrimitive
+from orkengine.lev2 import RigidPrimitive, MicroMesh
 
 lev2_pyexdir.addToSysPath()
 from lev2utils.cameras import setupUiCamera
@@ -28,7 +28,9 @@ tokens = CrcStringProxy()
 ################################################################################
 
 def make_sphere_arrays(radius=1.0, n=16):
-  """Generate sphere vertex data as numpy arrays for fromArrays."""
+  """Generate sphere data as (verts, norms, binormals, faces) — faces are
+  authored CCW-from-outside; MicroMesh handles winding for the vtxcolor
+  forward technique internally."""
   verts = []
   norms = []
   for i in range(n + 1):
@@ -42,29 +44,25 @@ def make_sphere_arrays(radius=1.0, n=16):
       norms.append((x, y, z))
 
   w = n * 2
-  indices = []
+  faces = []
   for i in range(n):
     for j in range(w):
       a = i * w + j
       b = a + 1 if j < w - 1 else i * w
       c = a + w
       d = c + 1 if j < w - 1 else (i + 1) * w
-      # CW winding for orkid
-      indices.extend([a, c, b, b, c, d])
+      faces.extend([3, a, b, c, 3, b, d, c])
 
   nv = len(verts)
   verts_np = np.array(verts, dtype=np.float32)
   norms_np = np.array(norms, dtype=np.float32)
-  # Compute binormals from normals
   up = np.array([0, 1, 0], dtype=np.float32)
   binormals_np = np.cross(norms_np, up)
   degen = np.linalg.norm(binormals_np, axis=1) < 1e-6
   binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
   lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
   binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
-  uvs_np = np.zeros((nv, 2), dtype=np.float32)
-  indices_np = np.array(indices, dtype=np.uint32)
-  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+  return verts_np, norms_np, binormals_np, faces
 
 ################################################################################
 # Material definitions: (name, color_rgb, roughness, metallic, alpha_blend)
@@ -111,7 +109,8 @@ class ProceduralMaterialsApp(object):
     self.normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
 
     # Sphere mesh data (shared across all materials)
-    verts_np, norms_np, binormals_np, uvs_np, indices_np = make_sphere_arrays(radius=1.0, n=16)
+    verts_np, norms_np, binormals_np, faces = make_sphere_arrays(radius=1.0, n=16)
+    nv = len(verts_np)
 
     self.material_keep_alive = []
     self.nodes = []
@@ -120,21 +119,20 @@ class ProceduralMaterialsApp(object):
     start_x = -(len(MATERIALS) - 1) * spacing / 2.0
 
     for i, (name, color, roughness, metallic, alpha_blend) in enumerate(MATERIALS):
-      # Create vertex colors
-      nv = len(verts_np)
       r, g, b = color
       a = 0.3 if alpha_blend else 1.0
-      colors_np = np.zeros((nv, 4), dtype=np.uint8)
-      colors_np[:, 0] = int(r * 255)
-      colors_np[:, 1] = int(g * 255)
-      colors_np[:, 2] = int(b * 255)
-      colors_np[:, 3] = int(a * 255)
+      # Pack as BGRA — MicroMesh::updateRigidPrim packs via fvec4::ARGBU32
+      # which lands as BGRA in memory; the GPU reads RGBA, so pre-swap
+      # R/B at the source so visible color matches the requested RGB.
+      colors_np = np.tile(np.array([b, g, r, a], dtype=np.float32), (nv, 1))
 
-      # Create RigidPrimitive via fromArrays
+      mesh = MicroMesh.fromVertAndFaceLists(verts_np, faces)
+      mesh.updateNormals(norms_np)
+      mesh.updateBinormals(binormals_np)
+      mesh.updateColors(colors_np)
       prim = RigidPrimitive()
-      prim.fromArrays(verts_np, norms_np, binormals_np, uvs_np, colors_np, indices_np, ctx)
+      prim.updateWithMicroMesh(mesh, ctx, tokens.TRIANGLES)
 
-      # Create PBR material
       mtl = lev2.PBRMaterial()
       mtl.assignImages(ctx, color=self.white_img, normal=self.normal_img,
                        mtlruf=self.white_img, doConform=True)
@@ -146,7 +144,6 @@ class ProceduralMaterialsApp(object):
       mtl.gpuInit(ctx)
       self.material_keep_alive.append(mtl)
 
-      # Create node
       node = prim.createNode(f"sphere_{name}", self.layer1, mtl)
       node.worldTransform.translation = vec3(start_x + i * spacing, 1.2, 0)
       node.sortkey = 20 if alpha_blend else 10

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env ork.python
+
+################################################################################
+# Procedural PBR Materials Test
+# Demonstrates RigidPrimitive.fromArrays with PBR vertex-color technique,
+# per-object roughness/metallic via PBRMaterial, and ModColor tint/opacity.
+# Renders a row of spheres with different PBR material properties.
+# Copyright 1996-2023, Michael T. Mayers.
+# Distributed under the MIT License
+# see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+################################################################################
+
+import math, sys, signal
+import numpy as np
+from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
+from orkengine import lev2
+from orkengine.lev2 import RigidPrimitive
+
+lev2_pyexdir.addToSysPath()
+from lev2utils.cameras import setupUiCamera
+from lev2utils.primitives import createGridData
+from lev2utils.scenegraph import createSceneGraph
+
+tokens = CrcStringProxy()
+
+################################################################################
+# Generate sphere mesh data as numpy arrays
+################################################################################
+
+def make_sphere_arrays(radius=1.0, n=16):
+  """Generate sphere vertex data as numpy arrays for fromArrays."""
+  verts = []
+  norms = []
+  for i in range(n + 1):
+    lat = math.pi * i / n
+    for j in range(n * 2):
+      lon = math.tau * j / (n * 2)
+      x = math.sin(lat) * math.cos(lon)
+      y = math.cos(lat)
+      z = math.sin(lat) * math.sin(lon)
+      verts.append((x * radius, y * radius, z * radius))
+      norms.append((x, y, z))
+
+  w = n * 2
+  indices = []
+  for i in range(n):
+    for j in range(w):
+      a = i * w + j
+      b = a + 1 if j < w - 1 else i * w
+      c = a + w
+      d = c + 1 if j < w - 1 else (i + 1) * w
+      # CW winding for orkid
+      indices.extend([a, c, b, b, c, d])
+
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  # Compute binormals from normals
+  up = np.array([0, 1, 0], dtype=np.float32)
+  binormals_np = np.cross(norms_np, up)
+  degen = np.linalg.norm(binormals_np, axis=1) < 1e-6
+  binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
+  lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
+  binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
+  uvs_np = np.zeros((nv, 2), dtype=np.float32)
+  indices_np = np.array(indices, dtype=np.uint32)
+  return verts_np, norms_np, binormals_np, uvs_np, indices_np
+
+################################################################################
+# Material definitions: (name, color_rgb, roughness, metallic, alpha_blend)
+################################################################################
+
+MATERIALS = [
+  ("gold",     (0.8, 0.7, 0.2),  0.3, 1.0, False),
+  ("chrome",   (0.9, 0.9, 0.9),  0.0, 1.0, False),
+  ("chalk",    (0.8, 0.75, 0.7), 1.0, 0.0, False),
+  ("obsidian", (0.05, 0.05, 0.06), 0.1, 0.0, False),
+  ("copper",   (0.7, 0.4, 0.2),  0.2, 1.0, False),
+  ("plastic",  (0.6, 0.1, 0.1),  0.3, 0.0, False),
+  ("glass",    (0.9, 0.95, 1.0), 0.0, 0.0, True),
+]
+
+################################################################################
+
+class ProceduralMaterialsApp(object):
+
+  def __init__(self):
+    super().__init__()
+    self.ezapp = lev2.OrkEzApp.create(self, width=1280, height=720)
+    self.ezapp.setRefreshPolicy(lev2.RefreshFastest, 0)
+    setupUiCamera(app=self, eye=vec3(0, 3, 12), tgt=vec3(0, 1, 0))
+    signal.signal(signal.SIGINT, lambda s, f: self.ezapp.signalExit())
+    self.time = 0.0
+
+  ##############################################
+
+  def onGpuInit(self, ctx):
+    createSceneGraph(app=self)
+
+    # Grid
+    self.grid_data = createGridData()
+    self.grid_node = self.layer1.createDrawableNodeFromData("grid", self.grid_data)
+    self.grid_node.sortkey = 1
+
+    # White textures for PBR (vertex colors provide albedo)
+    self.white_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.full((4, 4, 4), 255, dtype=np.uint8))
+    self.normal_img = lev2.Image.createFromBuffer(4, 4, "RGBA8",
+      np.tile(np.array([128, 128, 255, 255], dtype=np.uint8), (4, 4, 1)))
+
+    # Sphere mesh data (shared across all materials)
+    verts_np, norms_np, binormals_np, uvs_np, indices_np = make_sphere_arrays(radius=1.0, n=16)
+
+    self.material_keep_alive = []
+    self.nodes = []
+
+    spacing = 2.5
+    start_x = -(len(MATERIALS) - 1) * spacing / 2.0
+
+    for i, (name, color, roughness, metallic, alpha_blend) in enumerate(MATERIALS):
+      # Create vertex colors
+      nv = len(verts_np)
+      r, g, b = color
+      a = 0.3 if alpha_blend else 1.0
+      colors_np = np.zeros((nv, 4), dtype=np.uint8)
+      colors_np[:, 0] = int(r * 255)
+      colors_np[:, 1] = int(g * 255)
+      colors_np[:, 2] = int(b * 255)
+      colors_np[:, 3] = int(a * 255)
+
+      # Create RigidPrimitive via fromArrays
+      prim = RigidPrimitive()
+      prim.fromArrays(verts_np, norms_np, binormals_np, uvs_np, colors_np, indices_np, ctx)
+
+      # Create PBR material
+      mtl = lev2.PBRMaterial()
+      mtl.assignImages(ctx, color=self.white_img, normal=self.normal_img,
+                       mtlruf=self.white_img, doConform=True)
+      mtl.baseColor = vec4(1, 1, 1, 1)
+      mtl.roughnessFactor = roughness
+      mtl.metallicFactor = metallic
+      if alpha_blend:
+        mtl.alphaBlend = True
+      mtl.gpuInit(ctx)
+      self.material_keep_alive.append(mtl)
+
+      # Create node
+      node = prim.createNode(f"sphere_{name}", self.layer1, mtl)
+      node.worldTransform.translation = vec3(start_x + i * spacing, 1.2, 0)
+      node.sortkey = 20 if alpha_blend else 10
+      self.nodes.append((node, prim, name))
+
+    # Point light
+    self.point_light = lev2.DynamicPointLight()
+    self.point_light.data.color = vec3(1, 0.95, 0.85)
+    self.point_light.data.intensity = 5.0
+    self.point_light.data.radius = 30.0
+    self.light_node = self.point_light.data.createNode("key_light", self.layer1)
+    self.light_node.worldTransform.translation = vec3(3, 5, 5)
+
+    self.scene.lightingmanager.gpuInit(ctx)
+
+    print("Procedural PBR Materials Test:")
+    for i, (name, color, roughness, metallic, alpha_blend) in enumerate(MATERIALS):
+      print(f"  {name}: rough={roughness} metal={metallic} alpha={alpha_blend}")
+
+  ##############################################
+
+  def onGpuUpdate(self, ctx):
+    pass
+
+  def onUiEvent(self, uievent):
+    handled = self.uicam.uiEventHandler(uievent)
+    if handled:
+      self.camera.copyFrom(self.uicam.cameradata)
+    return lev2.ui.HandlerResult()
+
+  def onUpdate(self, updinfo):
+    self.time = updinfo.absolutetime
+    self.scene.updateScene(self.cameralut)
+
+################################################################################
+
+if __name__ == "__main__":
+  app = ProceduralMaterialsApp()
+  app.ezapp.mainThreadLoop()

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py
@@ -157,8 +157,8 @@ class ProceduralMaterialsApp(object):
     self.point_light.data.color = vec3(1, 0.95, 0.85)
     self.point_light.data.intensity = 5.0
     self.point_light.data.radius = 30.0
-    self.light_node = self.point_light.data.createNode("key_light", self.layer1)
-    self.light_node.worldTransform.translation = vec3(3, 5, 5)
+    self.light_node = self.layer1.createLightNode("key_light", self.point_light)
+    self.light_node.setMatrix(mtx4.transMatrix(vec3(3, 5, 5)))
 
     self.scene.lightingmanager.gpuInit(ctx)
 

--- a/ork.lev2/src/gfx/fx_pipeline.cpp
+++ b/ork.lev2/src/gfx/fx_pipeline.cpp
@@ -24,6 +24,7 @@ uint64_t FxPipelinePermutation::genIndex() const {
   index += (uint64_t(_skinned) << 3);
   index += (uint64_t(_is_picking) << 4);
   index += (uint64_t(_has_vtxcolors) << 5);
+  index += (uint64_t(_is_alpha) << 6);
   index += (uint64_t(_rendering_model) << 16);
 
   auto tekovr = uint64_t((const void*)_forced_technique);

--- a/ork.lev2/src/gfx/material/material_pbr.cpp
+++ b/ork.lev2/src/gfx/material/material_pbr.cpp
@@ -168,6 +168,7 @@ void PBRMaterial::gpuInit(Context* targ) /*final*/ {
 
   _tek_FWD_CT_NM_RI_NI_MO = fxi->technique(_shader, "FWD_CT_NM_RI_NI_MO"s + _shader_suffix);
   _tek_FWD_CV_NM_RI_NI_MO = fxi->technique(_shader, "FWD_CV_NM_RI_NI_MO"s + _shader_suffix);
+  _tek_FWD_CV_NM_RI_NI_MO_ALPHA = fxi->technique(_shader, "FWD_CV_NM_RI_NI_MO_ALPHA"s + _shader_suffix);
   _tek_FWD_CT_NM_RI_IN_MO = fxi->technique(_shader, "FWD_CT_NM_RI_IN_MO"s + _shader_suffix);
   _tek_FWD_CT_NM_RI_NI_ST = fxi->technique(_shader, "FWD_CT_NM_RI_NI_ST"s + _shader_suffix);
   _tek_FWD_CT_NM_RI_IN_ST = fxi->technique(_shader, "FWD_CT_NM_RI_IN_ST"s + _shader_suffix);

--- a/ork.lev2/src/gfx/material/material_pbr.cpp
+++ b/ork.lev2/src/gfx/material/material_pbr.cpp
@@ -170,6 +170,8 @@ void PBRMaterial::gpuInit(Context* targ) /*final*/ {
   _tek_FWD_CV_NM_RI_NI_MO = fxi->technique(_shader, "FWD_CV_NM_RI_NI_MO"s + _shader_suffix);
   _tek_FWD_CV_NM_RI_NI_MO_ALPHA = fxi->technique(_shader, "FWD_CV_NM_RI_NI_MO_ALPHA"s + _shader_suffix);
   _tek_FWD_CT_NM_RI_IN_MO = fxi->technique(_shader, "FWD_CT_NM_RI_IN_MO"s + _shader_suffix);
+  _tek_FWD_CV_NM_RI_IN_MO = fxi->technique(_shader, "FWD_CV_NM_RI_IN_MO"s + _shader_suffix);
+  _tek_FWD_CV_NM_RI_IN_MO_ALPHA = fxi->technique(_shader, "FWD_CV_NM_RI_IN_MO_ALPHA"s + _shader_suffix);
   _tek_FWD_CT_NM_RI_NI_ST = fxi->technique(_shader, "FWD_CT_NM_RI_NI_ST"s + _shader_suffix);
   _tek_FWD_CT_NM_RI_IN_ST = fxi->technique(_shader, "FWD_CT_NM_RI_IN_ST"s + _shader_suffix);
 

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/forward/fwdnode_pipeline.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/forward/fwdnode_pipeline.cpp
@@ -201,6 +201,9 @@ fxpipeline_ptr_t PBRMaterial::_createFxPipelineFWD(const FxPipelinePermutation& 
       culltest = ECullTest::OFF;
     }
 
+    // Bump priority above the technique state block when the material wants
+    // to override its cull (e.g. mtl.doubleSided / PROBE rendering).
+    mut->_rasterstate->_priority = (this->_doubleSided || is_rendering_PROBE) ? (1 << 20) : 0;
     mut->_rasterstate->setCullTest(culltest);
     mut->_rasterstate->setDepthTest(EDepthTest::LEQUALS);
     if (this->_alphaMode == 2) { // BLEND

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/forward/fwdnode_pipeline.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/forward/fwdnode_pipeline.cpp
@@ -312,10 +312,17 @@ fxpipeline_ptr_t PBRMaterial::_createFxPipelineFWD(const FxPipelinePermutation& 
       }
     } else { // not skinned
       if (permu._instanced) {
-        if (this->_tek_FWD_CT_NM_RI_IN_MO) {
+        if (permu._has_vtxcolors) {
+          if (permu._is_alpha && this->_tek_FWD_CV_NM_RI_IN_MO_ALPHA) {
+            pipeline             = std::make_shared<FxPipeline>(permu);
+            pipeline->_technique = this->_tek_FWD_CV_NM_RI_IN_MO_ALPHA;
+          } else if (this->_tek_FWD_CV_NM_RI_IN_MO) {
+            pipeline             = std::make_shared<FxPipeline>(permu);
+            pipeline->_technique = this->_tek_FWD_CV_NM_RI_IN_MO;
+          }
+        } else if (this->_tek_FWD_CT_NM_RI_IN_MO) {
           pipeline             = std::make_shared<FxPipeline>(permu);
           pipeline->_technique = this->_tek_FWD_CT_NM_RI_IN_MO;
-          //printf( "got fwdtek FWD_CT_NM_RI_IN_MO\n");
         }
       } else {
         if( permu._has_vtxcolors ){

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/forward/fwdnode_pipeline.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/forward/fwdnode_pipeline.cpp
@@ -41,7 +41,6 @@ FxPipeline::statelambda_t createForwardLightingLambda(const PBRMaterial* mtl) {
 
   auto L = [mtl](const RenderContextInstData& RCID) {
 
-    //printf( "LIGHTINGLAMBDA\n");
     auto RCFD             = RCID.rcfd();
     auto context    = RCFD->GetTarget();
     auto FXI        = context->FXI();
@@ -320,10 +319,13 @@ fxpipeline_ptr_t PBRMaterial::_createFxPipelineFWD(const FxPipelinePermutation& 
         }
       } else {
         if( permu._has_vtxcolors ){
-          if (this->_tek_FWD_CV_NM_RI_NI_MO) {
+          if (permu._is_alpha && this->_tek_FWD_CV_NM_RI_NI_MO_ALPHA) {
+            pipeline             = std::make_shared<FxPipeline>(permu);
+            pipeline->_technique = this->_tek_FWD_CV_NM_RI_NI_MO_ALPHA;
+          }
+          else if (this->_tek_FWD_CV_NM_RI_NI_MO) {
             pipeline             = std::make_shared<FxPipeline>(permu);
             pipeline->_technique = this->_tek_FWD_CV_NM_RI_NI_MO;
-            //printf( "got fwdtek FWD_CV_NM_SK_NI_MO\n");
           }
         }
         else{

--- a/ork.lev2/src/gfx/vulkan/headers/vulkan_ctx.h
+++ b/ork.lev2/src/gfx/vulkan/headers/vulkan_ctx.h
@@ -664,6 +664,7 @@ struct VkFxInterface final : public FxInterface {
 
   void _doPushRasterState(rasterstate_ptr_t rs) final;
   rasterstate_ptr_t _doPopRasterState() final;
+  void applyRasterState(const RasterState& rstate) final;
 
   void _bindPipeline(VkCommandBuffer cmdbuf, vkpipeline_obj_ptr_t pipe);
   void _uploadPipelineData(VkCommandBuffer cmdbuf, vkpipeline_obj_ptr_t pipe);
@@ -1005,6 +1006,7 @@ public:
   PFN_vkCmdBeginRendering _vkCmdBeginRenderingKHR             = nullptr;
   PFN_vkCmdEndRendering _vkCmdEndRenderingKHR                 = nullptr;
   PFN_vkCmdInsertDebugUtilsLabelEXT _vkCmdInsertDebugUtilsLabelEXT = nullptr;
+  PFN_vkCmdSetCullModeEXT _vkCmdSetCullModeEXT                = nullptr;
   //////////////////////////////////////////////
   // Buffers pending cleanup - accumulated when no primary CB is active
   // Moved to primary CB's cleanup list when a new primary CB begins

--- a/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_ctx.cpp
@@ -159,6 +159,9 @@ void VkContext::_initVulkanForDevInfo(vkdeviceinfo_ptr_t vk_devinfo) {
   _device_extensions.push_back(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
   logchan_vkctx->log("Added YCbCr sampler conversion extension for video decode");
 
+  // dynamic cull mode (so mtl.doubleSided takes effect without rebuilding pipelines)
+  _device_extensions.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
+
   VkDeviceCreateInfo DCI = {};
   initializeVkStruct(DCI, VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO);
   DCI.queueCreateInfoCount    = _DQCIs.size();
@@ -171,19 +174,23 @@ void VkContext::_initVulkanForDevInfo(vkdeviceinfo_ptr_t vk_devinfo) {
   VkPhysicalDeviceTimelineSemaphoreFeatures timelineFeatures{};
   VkPhysicalDeviceDynamicRenderingFeatures dynrenderfeat{};
   VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcrFeatures{};
+  VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extDynStateFeatures{};
 
   initializeVkStruct(timelineFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES);
   initializeVkStruct(dynrenderfeat, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES);
   initializeVkStruct(ycbcrFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES);
+  initializeVkStruct(extDynStateFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT);
 
   timelineFeatures.timelineSemaphore = VK_TRUE;
   dynrenderfeat.dynamicRendering = VK_TRUE;
   ycbcrFeatures.samplerYcbcrConversion = VK_TRUE;
+  extDynStateFeatures.extendedDynamicState = VK_TRUE;
 
   DCI.pNext = (void*) & timelineFeatures;
   timelineFeatures.pNext = (void*) & dynrenderfeat;
   dynrenderfeat.pNext = (void*) & ycbcrFeatures;
-  ycbcrFeatures.pNext = (void*) nullptr;
+  ycbcrFeatures.pNext = (void*) & extDynStateFeatures;
+  extDynStateFeatures.pNext = (void*) nullptr;
 
   VkResult result = vkCreateDevice(_vkphysicaldevice, &DCI, nullptr, &_vkdevice);
   if (result != VK_SUCCESS) {
@@ -214,8 +221,10 @@ void VkContext::_initVulkanForDevInfo(vkdeviceinfo_ptr_t vk_devinfo) {
   // These are needed for both window and offscreen contexts
   _fetchDeviceProcAddr(_vkCmdBeginRenderingKHR, "vkCmdBeginRenderingKHR");
   _fetchDeviceProcAddr(_vkCmdEndRenderingKHR, "vkCmdEndRenderingKHR");
+  _fetchDeviceProcAddr(_vkCmdSetCullModeEXT, "vkCmdSetCullModeEXT");
   OrkAssertI(_vkCmdBeginRenderingKHR != nullptr, "_vkCmdBeginRenderingKHR function pointer is null!");
   OrkAssertI(_vkCmdEndRenderingKHR != nullptr, "_vkCmdEndRenderingKHR function pointer is null!");
+  OrkAssertI(_vkCmdSetCullModeEXT != nullptr, "_vkCmdSetCullModeEXT function pointer is null!");
 
   ////////////////////////////
   // Init Queues
@@ -301,6 +310,7 @@ void VkContext::_initVulkanForWindow(VkSurfaceKHR surface) {
     _vkCmdDebugMarkerInsertEXT = context0->_vkCmdDebugMarkerInsertEXT;
     _vkCmdBeginRenderingKHR = context0->_vkCmdBeginRenderingKHR;
     _vkCmdEndRenderingKHR = context0->_vkCmdEndRenderingKHR;
+    _vkCmdSetCullModeEXT = context0->_vkCmdSetCullModeEXT;
 
     _device_extensions = context0->_device_extensions;
     _num_queue_types = context0->_num_queue_types;
@@ -336,6 +346,7 @@ void VkContext::_initVulkanForOffscreen(DisplayBuffer* pBuf) {
     _vkCmdDebugMarkerInsertEXT = context0->_vkCmdDebugMarkerInsertEXT;
     _vkCmdBeginRenderingKHR = context0->_vkCmdBeginRenderingKHR;
     _vkCmdEndRenderingKHR = context0->_vkCmdEndRenderingKHR;
+    _vkCmdSetCullModeEXT = context0->_vkCmdSetCullModeEXT;
     _device_extensions = context0->_device_extensions;
     _num_queue_types = context0->_num_queue_types;
     _DQCIs = context0->_DQCIs;

--- a/ork.lev2/src/gfx/vulkan/vulkan_fxi.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fxi.cpp
@@ -86,6 +86,30 @@ rasterstate_ptr_t VkFxInterface::_doPopRasterState() {
   return popped;
 }
 
+// Sets the dynamic cull mode. Called after per-draw state lambdas have
+// mutated the material rasterstate, mirroring pipeline-create's priority
+// resolution (technique state-block wins on ties; l_rsi bumps the material
+// rasterstate priority for mtl.doubleSided / PROBE rendering).
+void VkFxInterface::applyRasterState(const RasterState& rstate) {
+  auto pri_cb = _contextVK->primary_cb();
+  if (!pri_cb) return;  // not in an active render pass
+
+  const RasterState* effective = &rstate;
+  if (_currentVKPASS && _currentVKPASS->_stateblock_rasterstate) {
+    auto sb_rs = _currentVKPASS->_stateblock_rasterstate;
+    if (sb_rs->_priority >= rstate._priority) {
+      effective = sb_rs.get();
+    }
+  }
+  VkCullModeFlags vk_cull_mode = VK_CULL_MODE_NONE;
+  switch (effective->_culltest) {
+    case ECullTest::OFF:        vk_cull_mode = VK_CULL_MODE_NONE;      break;
+    case ECullTest::PASS_FRONT: vk_cull_mode = VK_CULL_MODE_BACK_BIT;  break;
+    case ECullTest::PASS_BACK:  vk_cull_mode = VK_CULL_MODE_FRONT_BIT; break;
+  }
+  _contextVK->_vkCmdSetCullModeEXT(pri_cb->_vkcmdbuf, vk_cull_mode);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 int VkFxInterface::BeginBlock(fxtechnique_constptr_t tek, const RenderContextInstData& data) {

--- a/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines_bind.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines_bind.cpp
@@ -104,6 +104,9 @@ void VkFxInterface::_bindPipeline(VkCommandBuffer cmdbuf, vkpipeline_obj_ptr_t p
   };
   vkCmdSetBlendConstants(cmdbuf, bc);
 
+  // Dynamic cull mode is set in VkFxInterface::applyRasterState, which
+  // runs after per-draw state lambdas have mutated the material rasterstate.
+
   ////////////////////////////////////////
   // upload ubo data and push constants
   ////////////////////////////////////////

--- a/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines_create.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines_create.cpp
@@ -80,7 +80,8 @@ vkpipeline_obj_ptr_t VkFxInterface::_createPipeline(
   ////////////////////////////////////////////////////
 
   std::vector<VkDynamicState> dynamic_states = {
-      VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_BLEND_CONSTANTS};
+      VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_BLEND_CONSTANTS,
+      VK_DYNAMIC_STATE_CULL_MODE_EXT};
   VkPipelineDynamicStateCreateInfo dynamicState = {};
   initializeVkStruct(dynamicState, VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO);
   dynamicState.dynamicStateCount = dynamic_states.size();
@@ -524,7 +525,8 @@ vkpipeline_obj_ptr_t VkFxInterface::_createPipelineSSBO(vkprimclass_ptr_t primcl
   ////////////////////////////////////////////////////
 
   std::vector<VkDynamicState> dynamic_states = {
-      VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_BLEND_CONSTANTS};
+      VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_BLEND_CONSTANTS,
+      VK_DYNAMIC_STATE_CULL_MODE_EXT};
   VkPipelineDynamicStateCreateInfo dynamicState = {};
   initializeVkStruct(dynamicState, VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO);
   dynamicState.dynamicStateCount = dynamic_states.size();


### PR DESCRIPTION
  * **fwdtools.i2** —
      Bug fix (vertex-color technique was hardcoding metallic=1, roughness=1, and double-applying vertex color; point lights and envmaps had no effect on procedural geometry):
      * `forward_lighting_ntex`: albedo changed from `vec3(1,1,1)` → `modcolor` (vertex color becomes PBR albedo)
      * `ambrufmtl` changed from `vec3(1,1,1)` → `vec3(1, RoughnessFactor, MetallicFactor)` (reads material uniforms instead of hardcoded values)
      * Removed double `* modcolor` multiply — was squaring vertex color, killing envmap reflections
      * Passes `vec3(1)` as modcolor to `_forward_lightingZ` since the color is already in the albedo

      Double-sided lighting:
      * Added `if (!gl_FrontFacing) normal = -normal;` in `_forward_lighting` and `forward_lighting_ntex` so the effective normal always faces the camera, regardless of which side of a double-sided triangle the fragment is on.

  * **pbr.fxv2** —
      New techniques and state block (transparency support for procedural geometry; instanced rendering with vertex colors):
      * Added `sb_cullcw_alpha` state block (alpha blending + no depth writes)
      * Added `FWD_CV_NM_RI_NI_MO_ALPHA` technique (transparent vertex-color, non-instanced)
      * Added `FWD_CV_NM_RI_IN_MO` technique (opaque vertex-color, instanced)
      * Added `FWD_CV_NM_RI_IN_MO_ALPHA` technique (transparent vertex-color, instanced)

      Cleanup of pre-y-flip-fix relic (`sb_cullcw` and `sb_cullcw_alpha` previously overrode `CullTest = PASS_BACK` as a paired compensation with MicroMesh's silent winding reversal — both compensations were obsolete after `9359c9e20 remove the y flips (WIP)` and were fighting each other):
      * `sb_cullcw` now inherits `sb_default` unchanged (no cull override)
      * `sb_cullcw_alpha` keeps its `BlendMode = ALPHA` and `DepthMask = false` but drops the cull override
      * Vertex-color techniques now use the same `PASS_FRONT` cull as everything else; CCW-from-outside winding flows through the whole pipeline cleanly

  * **pbrtools.i2** (new features) — Transparency, tint/opacity per object, instanced rendering with vertex colors.
      * `ps_forward_test_vtxcol`: output changed from `(lit, 1)` → `(lit * ModColor.rgb, frg_clr.a * ModColor.a)` — enables per-object tint and opacity via ModColor
      * Added `ps_forward_test_vtxcol_alpha` — transparent fragment shader with luminance-based alpha boost for glass-like specular
      * Added `ps_forward_instanced_vtxcol_alpha` — instanced transparent fragment shader (no luminance boost, instance alpha = final opacity)
      * Added `vs_forward_instanced_vc` — instanced vertex shader that reads per-vertex colors AND per-instance colors, multiplies them

  * **stdtools.i2** (new feature) — Instanced rendering needs to combine per-vertex colors with per-instance colors.
      * Added `lib_pbr_vtx_instanced_vc` — vertex-color-aware instanced vertex transform lib block

  * **fx_pipeline.h** — Pipeline cache needs to distinguish opaque vs transparent permutations.
      * Added `bool _is_alpha = false` to `FxPipelinePermutation`

  * **material_pbr.inl** — PBRMaterial needs new technique pointers and alpha blending flag.
      * Added technique pointers: `_tek_FWD_CV_NM_RI_IN_MO`, `_tek_FWD_CV_NM_RI_IN_MO_ALPHA`, `_tek_FWD_CV_NM_RI_NI_MO_ALPHA`
      * Added `bool _alphaBlend = false`

  * **rigid_primitive.inl** — Alpha blending support and instanced rendering for procedural geometry.
      * Added `#include <ork/lev2/gfx/material_pbr.inl>` for PBRMaterial access
      * `installInCallbackDrawable`: checks `_alphaBlend` to set `permu._is_alpha`
      * Added `renderInstancedEML()` — instanced draw call
      * Added `InstancedRigidPrimitiveDrawable` — full instanced rendering drawable for procedural geometry

  * **pyext_micromesh.inl** — Cleanup + RGBA support.
      * `MicroMesh::updateFromLists` no longer reverses triangle/quad indices on parse — input order is preserved (the reversal was the other half of the `sb_cullcw` compensation pair)
      * `_colors` changed from `vector<fvec3>` to `vector<fvec4>` so per-vertex alpha survives upload
      * Added `loadVec4Data` helper (parallel sibling of `loadVec3Data`); `updateColors` now accepts (N,3) → alpha=1 or (N,4) numpy/list

  * **pyext_gfx_lighting.cpp** — Missing properties needed to create and configure dynamic lights from Python.
      * Added `LightData.intensity` and `LightData.shadowCaster` properties
      * Added `PointLightData.radius` and `PointLightData.falloff` properties
      * Added `DynamicPointLight()` constructor and `.data` property
      * Added `SpotLightData.createNode()` method

  * **pyext_gfx_pbr.cpp** — Python needs to set alpha blending on materials.
      * Added `PBRMaterial.alphaBlend` property

  * **pyext_gfx_primitives_rigid.cpp** — Instanced rendering from Python.
      * Added `RigidPrimitive.createInstancedNode()` — creates instanced drawable node
      * (Note: an earlier iteration of this PR added a `RigidPrimitive.fromArrays()` for direct GPU buffer upload from numpy, plus a `RigidPrimitive.fromVertsAndFacesDict()` helper. Both have been removed in favor of routing all procedural geometry through `MicroMesh.fromVertAndFaceLists` + `updateWithMicroMesh`, which now does the same job after the MicroMesh winding-reversal cleanup.)

  * **pyext_gfx_scenegraph.cpp** (bug fix) — Instance data bindings were hardcoded to `InstancedModelDrawable`.
      * Changed `dynamic_pointer_cast<InstancedModelDrawable>` → `dynamic_pointer_cast<InstancedDrawable>` in `instanceData`, `setInstanceMatrix`, `setInstanceColor`

  * **fx_pipeline.cpp** — Pipeline cache index needs the alpha bit.
      * Added `_is_alpha` to `genIndex()`: `index += (uint64_t(_is_alpha) << 6)`

  * **material_pbr.cpp** — gpuInit needs to load new technique pointers.
      * Added technique lookups for `FWD_CV_NM_RI_NI_MO_ALPHA`, `FWD_CV_NM_RI_IN_MO`, `FWD_CV_NM_RI_IN_MO_ALPHA`

  * **fwdnode_pipeline.cpp** —
      Forward pipeline technique selection for new permutations:
      * Updated pipeline selection to handle instanced + vertex-color combinations
      * Handles `_is_alpha` flag for both instanced and non-instanced vertex-color paths

      `mtl.doubleSided` now actually takes effect for vertex-color techniques:
      * `l_rsi` per-frame state lambda bumps the material rasterstate's `_priority` to `1 << 20` when `_doubleSided` or PROBE rendering wants to override the technique's static cull. Combined with the priority resolution in `VkFxInterface::applyRasterState`, this makes `mtl.doubleSided=True` actually take effect (previously the technique state-block always won at pipeline creation and `_doubleSided` was a no-op for vertex-color geometry).

  * **vulkan_ctx.cpp / vulkan_ctx.h** — Enable Vulkan dynamic cull mode so material rasterstate overrides take effect at draw time.
      * Added `VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME` to enabled device extensions
      * Added `VkPhysicalDeviceExtendedDynamicStateFeaturesEXT{extendedDynamicState=VK_TRUE}` to the `vkCreateDevice` pNext chain
      * Added `_vkCmdSetCullModeEXT` PFN field on the context, loaded via `vkGetDeviceProcAddr` after device creation, propagated to subsequent share-group contexts

  * **vulkan_fxi_pipelines_create.cpp** — Added `VK_DYNAMIC_STATE_CULL_MODE_EXT` to the pipeline's `dynamic_states` list (both vertex-buffer and SSBO-only paths). Pipelines no longer bake the static cullMode.

  * **vulkan_fxi.cpp** (new override) — `VkFxInterface::applyRasterState` sets the dynamic cull mode each draw.
      * Mirrors pipeline-create's priority resolution: technique state-block wins on ties; material rasterstate wins when its priority is bumped above (e.g. `mtl.doubleSided=True`).
      * Guards against being called outside an active render pass (returns early when no primary command buffer is bound).

  * **vulkan_fxi_pipelines_bind.cpp** — Comment-only update; per-draw cull mode is now set in `applyRasterState` (which runs after the per-draw state lambdas have mutated material rasterstate, so the priority bump from `l_rsi` is visible).


Tests
```
# Procedural PBR materials (gold, chrome, chalk, obsidian, copper, plastic, glass)
ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/vtxcolor_materials.py

# Transparency (fixed alpha, animated opacity, animated tint, opaque-inside-transparent)
ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/transparency.py

# Point lights (3 colored lights orbiting matte/metallic/mirror spheres)
ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/point_lights.py

# GPU instancing (500 opaque + 200 transparent instances with animated transforms)
ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/instancing.py

# Basic cube + sphere + light - are all 4 sides of the cube getting point light OK?
# Is the environment map's lighting contribution upside down?
ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py
# Same test with gold material instead of chalk:
ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/basic_cube_sphere_light.py --gold
```