### PR TITLE
procedural environment maps + point lights with independent radius and intensity

### DIFF
--- a/ork.data/platform_lev2/shaders/fxv2/envtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/envtools.i2
@@ -96,15 +96,21 @@ libblock lib_envmapping
   vec3 env_cube(samplerCube envtex,vec3 normal) {
     return textureLod(envtex, normal,0).xyz;
   }
+  // V mapping: use linear (1.0 - uv.y) instead of -uv.y. Mathematically the
+  // same for non-pole points (under WRAP, fract(-V) == 1-V for V in (0,1)),
+  // but no fract discontinuity at V=0 / V=1, so bilinear filtering at the
+  // literal pole + CLAMP_TO_EDGE on the V axis no longer blends across the
+  // wraparound seam. Fixes both the chrome-ball pole-darkening and the
+  // long-standing diffuse-envmap-upside-down chalk artifact.
   vec3 env_equirectangular_spec_wbias(vec3 normal, sampler2DArray envtex, float slice, float bias) {
     vec3 n  = vec3(normal.x, normal.z, normal.y);
     vec2 uv = env_equirectangularN2UV(n);
-    return textureLod(envtex, vec3(-uv.x, -uv.y,slice),0).xyz;
+    return textureLod(envtex, vec3(-uv.x, 1.0 - uv.y, slice), 0).xyz;
   }
   vec3 env_equirectangular_spec(vec3 normal, sampler2DArray envtex, float slice) {
     vec3 n  = vec3(normal.x, normal.z, normal.y);
     vec2 uv = env_equirectangularN2UV(n);
-    return texture(envtex, vec3(-uv.x, -uv.y,slice)).xyz;
+    return texture(envtex, vec3(-uv.x, 1.0 - uv.y, slice)).xyz;
   }
   vec3 env_equirectangular_spec_flipv(vec3 normal, sampler2DArray envtex, float slice) {
     vec3 n  = vec3(normal.x, normal.y, normal.z);
@@ -122,12 +128,12 @@ libblock lib_envmapping
     vec3 env_equirectangular(vec3 normal, sampler2D envtex, float miplevel) {
     vec3 n  = vec3(normal.x, normal.y, normal.z);
     vec2 uv = env_equirectangularN2UV(n);
-    return textureLod(envtex, vec2(-uv.x, -uv.y), miplevel).xyz;
+    return textureLod(envtex, vec2(-uv.x, 1.0 - uv.y), miplevel).xyz;
   }
   vec3 env_equirectangular2(vec3 normal, sampler2D envtex) {
     vec3 n  = vec3(normal.x, normal.y, normal.z);
     vec2 uv = env_equirectangularN2UVa(n);
-    return textureLod(envtex, vec2(-uv.x, -uv.y),7).xyz;
+    return textureLod(envtex, vec2(-uv.x, 1.0 - uv.y), 7).xyz;
   }
   vec3 env_equirectangularFlipV(vec3 normal, sampler2D envtex, float miplevel) {
     vec3 n  = vec3(normal.x, normal.y, normal.z);

--- a/ork.data/platform_lev2/shaders/fxv2/envtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/envtools.i2
@@ -96,12 +96,10 @@ libblock lib_envmapping
   vec3 env_cube(samplerCube envtex,vec3 normal) {
     return textureLod(envtex, normal,0).xyz;
   }
-  // V mapping: use linear (1.0 - uv.y) instead of -uv.y. Mathematically the
-  // same for non-pole points (under WRAP, fract(-V) == 1-V for V in (0,1)),
-  // but no fract discontinuity at V=0 / V=1, so bilinear filtering at the
-  // literal pole + CLAMP_TO_EDGE on the V axis no longer blends across the
-  // wraparound seam. Fixes both the chrome-ball pole-darkening and the
-  // long-standing diffuse-envmap-upside-down chalk artifact.
+  // V mapping uses (1.0 - uv.y) rather than -uv.y. Mathematically equivalent
+  // for non-pole points under WRAP (fract(-V) == 1-V for V in (0,1)), but
+  // without the fract discontinuity at V=0 / V=1 — so bilinear filtering at
+  // the poles plus CLAMP_TO_EDGE on V does not blend across the seam.
   vec3 env_equirectangular_spec_wbias(vec3 normal, sampler2DArray envtex, float slice, float bias) {
     vec3 n  = vec3(normal.x, normal.z, normal.y);
     vec2 uv = env_equirectangularN2UV(n);

--- a/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
@@ -26,13 +26,10 @@ libblock lib_fwd_impl : lib_math //
     return plc;
   }
   vec3 plcalc_forward(LightCtx plc, PbrData pbd, float lightRadius) {
-    // Linear distance falloff:
-    //   - atten = 1 at the source, ramps linearly to 0 at lightRadius
-    //   - no inverse-square term — intensity and radius are independent
-    //     controls (intensity = peak brightness, radius = lit extent), so
-    //     the lit disc actually reaches the nominal radius on a ground.
-    float dist2light = length(plc._lightdel);
-    float r_ratio    = dist2light / max(lightRadius, 1e-4);
+    // Linear distance falloff: atten ramps from 1 at the source to 0 at
+    // lightRadius. intensity and radius are independent controls.
+    float dist_to_light = length(plc._lightdel);
+    float r_ratio    = dist_to_light / max(lightRadius, 1e-4);
     float atten      = max(0.0, 1.0 - r_ratio);
     vec3 lightdir    = normalize(plc._lightdel);
     vec3 halfdir     = normalize(plc._viewdir + lightdir);

--- a/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
@@ -320,10 +320,9 @@ libblock lib_fwd     //
 
   vec3 forward_lighting_ntex(vec3 modcolor) {
     vec2 uvinvy    = abs(frg_uv0.xy);
-    // No-texture path: per-vertex color (modcolor) and per-material ModAlbedo
-    // both feed albedo as multiplicative factors. With the default white
-    // ModAlbedo this preserves the old "vertex color is albedo" behavior;
-    // setting mtl.baseColor adds a per-material tint on top of vertex colors.
+    // No-texture path: vertex color and per-material ModAlbedo both feed
+    // albedo as multiplicative factors, so mtl.baseColor tints all vertices
+    // uniformly and the default white ModAlbedo leaves vertex color as-is.
     vec3 albedo    = ModAlbedo.xyz * modcolor;
     vec3 TN        = vec3(0.5,0.5,1);
     vec3 ambrufmtl = vec3(1, RoughnessFactor, MetallicFactor);

--- a/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
@@ -320,10 +320,11 @@ libblock lib_fwd     //
 
   vec3 forward_lighting_ntex(vec3 modcolor) {
     vec2 uvinvy    = abs(frg_uv0.xy);
-    // No-texture path: ModAlbedo IS the albedo (modulating the implicit
-    // white "no texture" base). modcolor stays a post-multiplier — no
-    // longer doubles as albedo.
-    vec3 albedo    = ModAlbedo.xyz;
+    // No-texture path: per-vertex color (modcolor) and per-material ModAlbedo
+    // both feed albedo as multiplicative factors. With the default white
+    // ModAlbedo this preserves the old "vertex color is albedo" behavior;
+    // setting mtl.baseColor adds a per-material tint on top of vertex colors.
+    vec3 albedo    = ModAlbedo.xyz * modcolor;
     vec3 TN        = vec3(0.5,0.5,1);
     vec3 ambrufmtl = vec3(1, RoughnessFactor, MetallicFactor);
     vec3 emission  = vec3(0,0,0);

--- a/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
+++ b/ork.data/platform_lev2/shaders/fxv2/fwdtools.i2
@@ -26,14 +26,17 @@ libblock lib_fwd_impl : lib_math //
     return plc;
   }
   vec3 plcalc_forward(LightCtx plc, PbrData pbd, float lightRadius) {
-    float dist2light    = length(plc._lightdel);
-    float atten         = 1.0 / max(.05, dist2light * dist2light); // prevent infinite light
-    vec3 lightdir       = normalize(plc._lightdel);
-    vec3 halfdir        = normalize(plc._viewdir + lightdir);
-    float angularRadius = atan(lightRadius, dist2light);
-    float ggx           = computeGGX(plc._normal, halfdir, plc._roughness + angularRadius); // Example adjustment
-
-    // float ggx = computeGGX(plc._normal, halfdir, plc._roughness);
+    // Linear distance falloff:
+    //   - atten = 1 at the source, ramps linearly to 0 at lightRadius
+    //   - no inverse-square term — intensity and radius are independent
+    //     controls (intensity = peak brightness, radius = lit extent), so
+    //     the lit disc actually reaches the nominal radius on a ground.
+    float dist2light = length(plc._lightdel);
+    float r_ratio    = dist2light / max(lightRadius, 1e-4);
+    float atten      = max(0.0, 1.0 - r_ratio);
+    vec3 lightdir    = normalize(plc._lightdel);
+    vec3 halfdir     = normalize(plc._viewdir + lightdir);
+    float ggx        = computeGGX(plc._normal, halfdir, plc._roughness);
     float geo = geometrySmith(plc._normal, plc._viewdir, lightdir, plc._roughness);
     vec3 fres = fresnelSchlickRoughness(satdot(halfdir, plc._viewdir), plc._F0, plc._roughness);
 

--- a/ork.lev2/inc/ork/lev2/gfx/meshutil/rigid_primitive.inl
+++ b/ork.lev2/inc/ork/lev2/gfx/meshutil/rigid_primitive.inl
@@ -742,6 +742,11 @@ struct InstancedRigidPrimitiveDrawable final : public lev2::InstancedDrawable {
     renderable._pickID = _pickID;
     renderable._sortkey = _sortkey;
     renderable._instanced = true;
+    // CallbackRenderables come from a pooled fixedvector that does not reset
+    // slots between frames; per-instance matrices already carry world-space
+    // positions, so force identity here to avoid inheriting a stale world
+    // matrix from a prior renderable that happened to land on the same slot.
+    renderable.SetMatrix(fmtx4());
     renderable.SetModColor(fcolor4::White());
     renderable.SetDrawableDataA(GetUserDataA());
     renderable.SetDrawableDataB(GetUserDataB());

--- a/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
+++ b/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
@@ -121,6 +121,11 @@ struct CommonStuff : public ork::Object {
   // we block — this routine self-pumps that queue.
   static radiancemaps_ptr_t requestRadianceMapsSync(const AssetPath& texture_path, lev2::Context* ctx);
 
+  // Build an in-memory RadianceMaps where every specular roughness slice and
+  // the diffuse map is a single uniform color. BRDF LUTs come from the
+  // PBRMaterial cache. Must be called on the GPU thread.
+  static radiancemaps_ptr_t makeRadianceMapsSolidColor(fvec3 color, lev2::Context* ctx);
+
   void onGpuInit(lev2::Context* ctx);
 
   radiancemaps_ptr_t _radiance_maps;

--- a/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
+++ b/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
@@ -121,13 +121,9 @@ struct CommonStuff : public ork::Object {
   // we block — this routine self-pumps that queue.
   static radiancemaps_ptr_t requestRadianceMapsSync(const AssetPath& texture_path, lev2::Context* ctx);
 
-  // Allocate procedural RadianceMaps (32x64 RGB8 specular array × 10 slices,
-  // 32x64 RGB8 diffuse, cached BRDF LUTs). Initial content is uniform black;
-  // call one of the update* functions to populate. GPU thread.
+  // Allocate procedural RadianceMaps (black). Populate via update* below.
+  // Update functions reuse the GPU textures, so calling every frame is safe.
   static radiancemaps_ptr_t makeProceduralRadianceMaps(lev2::Context* ctx);
-
-  // Update an existing procedural RadianceMaps in place. Reuses the GPU
-  // textures (no descriptor-set churn), so safe to call every frame.
   static void updateRadianceMapsSolidColor(
       radiancemaps_ptr_t maps, fvec3 color, lev2::Context* ctx);
   static void updateRadianceMapsGradient(

--- a/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
+++ b/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
@@ -121,11 +121,10 @@ struct CommonStuff : public ork::Object {
   // we block — this routine self-pumps that queue.
   static radiancemaps_ptr_t requestRadianceMapsSync(const AssetPath& texture_path, lev2::Context* ctx);
 
-  // Allocate procedural RadianceMaps (black). Populate via update* below.
-  // Update functions reuse the GPU textures, so calling every frame is safe.
+  // Allocate procedural RadianceMaps (black). Populate via updateRadianceMapsGradient.
+  // The update reuses the GPU textures, so calling every frame is safe.
+  // A single-stop gradient is equivalent to a solid color.
   static radiancemaps_ptr_t makeProceduralRadianceMaps(lev2::Context* ctx);
-  static void updateRadianceMapsSolidColor(
-      radiancemaps_ptr_t maps, fvec3 color, lev2::Context* ctx);
   static void updateRadianceMapsGradient(
       radiancemaps_ptr_t maps,
       const std::vector<std::pair<float, fvec3>>& stops,

--- a/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
+++ b/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
@@ -126,6 +126,13 @@ struct CommonStuff : public ork::Object {
   // PBRMaterial cache. Must be called on the GPU thread.
   static radiancemaps_ptr_t makeRadianceMapsSolidColor(fvec3 color, lev2::Context* ctx);
 
+  // Build an in-memory RadianceMaps from a vertical gradient. Stops are
+  // (t, color) pairs with t in [0,1] mapping top (0) to bottom (1) of the
+  // sphere; must be sorted ascending by t. Higher-roughness slices lerp
+  // toward the hemisphere-weighted average. Must be called on the GPU thread.
+  static radiancemaps_ptr_t makeRadianceMapsGradient(
+      const std::vector<std::pair<float, fvec3>>& stops, lev2::Context* ctx);
+
   void onGpuInit(lev2::Context* ctx);
 
   radiancemaps_ptr_t _radiance_maps;

--- a/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
+++ b/ork.lev2/inc/ork/lev2/gfx/renderer/NodeCompositor/pbr_common.h
@@ -121,17 +121,19 @@ struct CommonStuff : public ork::Object {
   // we block — this routine self-pumps that queue.
   static radiancemaps_ptr_t requestRadianceMapsSync(const AssetPath& texture_path, lev2::Context* ctx);
 
-  // Build an in-memory RadianceMaps where every specular roughness slice and
-  // the diffuse map is a single uniform color. BRDF LUTs come from the
-  // PBRMaterial cache. Must be called on the GPU thread.
-  static radiancemaps_ptr_t makeRadianceMapsSolidColor(fvec3 color, lev2::Context* ctx);
+  // Allocate procedural RadianceMaps (32x64 RGB8 specular array × 10 slices,
+  // 32x64 RGB8 diffuse, cached BRDF LUTs). Initial content is uniform black;
+  // call one of the update* functions to populate. GPU thread.
+  static radiancemaps_ptr_t makeProceduralRadianceMaps(lev2::Context* ctx);
 
-  // Build an in-memory RadianceMaps from a vertical gradient. Stops are
-  // (t, color) pairs with t in [0,1] mapping top (0) to bottom (1) of the
-  // sphere; must be sorted ascending by t. Higher-roughness slices lerp
-  // toward the hemisphere-weighted average. Must be called on the GPU thread.
-  static radiancemaps_ptr_t makeRadianceMapsGradient(
-      const std::vector<std::pair<float, fvec3>>& stops, lev2::Context* ctx);
+  // Update an existing procedural RadianceMaps in place. Reuses the GPU
+  // textures (no descriptor-set churn), so safe to call every frame.
+  static void updateRadianceMapsSolidColor(
+      radiancemaps_ptr_t maps, fvec3 color, lev2::Context* ctx);
+  static void updateRadianceMapsGradient(
+      radiancemaps_ptr_t maps,
+      const std::vector<std::pair<float, fvec3>>& stops,
+      lev2::Context* ctx);
 
   void onGpuInit(lev2::Context* ctx);
 

--- a/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
@@ -59,20 +59,25 @@ void pyinit_gfx_pbr(py::module& module_lev2) {
                 return pbr::CommonStuff::requestRadianceMapsSync(as_str, ctx.get());
               })
           .def_static(
-              "makeRadianceMapsSolidColor",
-              [](fvec3 color, ctx_t ctx) -> pbr::radiancemaps_ptr_t { //
-                return pbr::CommonStuff::makeRadianceMapsSolidColor(color, ctx.get());
+              "makeProceduralRadianceMaps",
+              [](ctx_t ctx) -> pbr::radiancemaps_ptr_t { //
+                return pbr::CommonStuff::makeProceduralRadianceMaps(ctx.get());
               })
           .def_static(
-              "makeRadianceMapsGradient",
-              [](py::list stops, ctx_t ctx) -> pbr::radiancemaps_ptr_t {
+              "updateRadianceMapsSolidColor",
+              [](pbr::radiancemaps_ptr_t maps, fvec3 color, ctx_t ctx) {
+                pbr::CommonStuff::updateRadianceMapsSolidColor(maps, color, ctx.get());
+              })
+          .def_static(
+              "updateRadianceMapsGradient",
+              [](pbr::radiancemaps_ptr_t maps, py::list stops, ctx_t ctx) {
                 std::vector<std::pair<float, fvec3>> cpp_stops;
                 cpp_stops.reserve(stops.size());
                 for (auto handle : stops) {
                   auto tup = handle.cast<py::tuple>();
                   cpp_stops.emplace_back(tup[0].cast<float>(), tup[1].cast<fvec3>());
                 }
-                return pbr::CommonStuff::makeRadianceMapsGradient(cpp_stops, ctx.get());
+                pbr::CommonStuff::updateRadianceMapsGradient(maps, cpp_stops, ctx.get());
               })
           .def(py::init<>())
           .def_property(

--- a/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
@@ -63,6 +63,17 @@ void pyinit_gfx_pbr(py::module& module_lev2) {
               [](fvec3 color, ctx_t ctx) -> pbr::radiancemaps_ptr_t { //
                 return pbr::CommonStuff::makeRadianceMapsSolidColor(color, ctx.get());
               })
+          .def_static(
+              "makeRadianceMapsGradient",
+              [](py::list stops, ctx_t ctx) -> pbr::radiancemaps_ptr_t {
+                std::vector<std::pair<float, fvec3>> cpp_stops;
+                cpp_stops.reserve(stops.size());
+                for (auto handle : stops) {
+                  auto tup = handle.cast<py::tuple>();
+                  cpp_stops.emplace_back(tup[0].cast<float>(), tup[1].cast<fvec3>());
+                }
+                return pbr::CommonStuff::makeRadianceMapsGradient(cpp_stops, ctx.get());
+              })
           .def(py::init<>())
           .def_property(
               "RadianceMaps",

--- a/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
@@ -64,11 +64,6 @@ void pyinit_gfx_pbr(py::module& module_lev2) {
                 return pbr::CommonStuff::makeProceduralRadianceMaps(ctx.get());
               })
           .def_static(
-              "updateRadianceMapsSolidColor",
-              [](pbr::radiancemaps_ptr_t maps, fvec3 color, ctx_t ctx) {
-                pbr::CommonStuff::updateRadianceMapsSolidColor(maps, color, ctx.get());
-              })
-          .def_static(
               "updateRadianceMapsGradient",
               [](pbr::radiancemaps_ptr_t maps, py::list stops, ctx_t ctx) {
                 std::vector<std::pair<float, fvec3>> cpp_stops;

--- a/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
+++ b/ork.lev2/pyext/src/pyext_gfx_pbr.cpp
@@ -58,6 +58,11 @@ void pyinit_gfx_pbr(py::module& module_lev2) {
                 auto as_str    = as_py_str.cast<std::string>();
                 return pbr::CommonStuff::requestRadianceMapsSync(as_str, ctx.get());
               })
+          .def_static(
+              "makeRadianceMapsSolidColor",
+              [](fvec3 color, ctx_t ctx) -> pbr::radiancemaps_ptr_t { //
+                return pbr::CommonStuff::makeRadianceMapsSolidColor(color, ctx.get());
+              })
           .def(py::init<>())
           .def_property(
               "RadianceMaps",

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
@@ -216,7 +216,7 @@ class ProceduralEnvmapsApp(object):
     self.last_radiance_key = key
     if self.mode == 1:
       color = SOLID_PALETTE[self.solid_idx % len(SOLID_PALETTE)]
-      lev2.PbrCommon.updateRadianceMapsSolidColor(self.proc_radiance, color, ctx)
+      lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, [(0.0, color)], ctx)
     else:
       lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, STATIC_GRADIENT, ctx)
 

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
@@ -2,17 +2,17 @@
 
 ################################################################################
 # Procedural Envmaps Test
-# Demonstrates lev2.PbrCommon.makeRadianceMapsSolidColor and
-# makeRadianceMapsGradient — in-memory radiance maps with no disk lag.
+# Demonstrates lev2.PbrCommon.makeProceduralRadianceMaps +
+# updateRadianceMapsGradient — radiance maps built in memory, no disk lag.
 #
-# Press 1: solid color background (cycles through several colors).
+# Press 1: solid color background (cycles through several colors, sent as a
+#          single-stop gradient).
 # Press 2: static vertical gradient (sky / horizon / ground).
 # Press 3: time-varying gradient (day-to-night cycle, rebuilt every frame).
 #
-# Layout follows scenegraph/shaderballs.py: a 9×9 grid on the floor where the
-# X axis sweeps metallic 0→1 and the Z axis sweeps roughness 0→1, with random
-# colors per sphere. Lets you see the full PBR matrix against the procedural
-# envmap.
+# Layout follows scenegraph/shaderballs.py: a 9×9 sphere grid where the X axis
+# sweeps metallic 0→1 and the Z axis sweeps roughness 0→1, with random
+# per-sphere colors. Shows the full PBR matrix against the procedural envmap.
 #
 # Copyright 1996-2023, Michael T. Mayers.
 # Distributed under the MIT License

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env ork.python
+
+################################################################################
+# Procedural Envmaps Test
+# Demonstrates lev2.PbrCommon.makeRadianceMapsSolidColor and
+# makeRadianceMapsGradient — in-memory radiance maps with no disk lag.
+#
+# Press 1: solid color background (cycles through several colors).
+# Press 2: static vertical gradient (sky / horizon / ground).
+# Press 3: time-varying gradient (day-to-night cycle, rebuilt every frame).
+#
+# A row of 9 spheres sweeps roughness 0→1 at metallic=1, plus an extra row at
+# metallic=0, so reflections and diffuse irradiance are both visible against
+# whichever envmap is active.
+#
+# Copyright 1996-2023, Michael T. Mayers.
+# Distributed under the MIT License
+# see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
+################################################################################
+
+import math, sys, signal
+import numpy as np
+from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
+from orkengine import lev2
+from orkengine.lev2 import RigidPrimitive, MicroMesh
+
+lev2_pyexdir.addToSysPath()
+from lev2utils.cameras import setupUiCamera
+from lev2utils.scenegraph import createSceneGraph
+
+tokens = CrcStringProxy()
+
+################################################################################
+
+def make_sphere_arrays(radius=1.0, n=16):
+  verts, norms = [], []
+  for i in range(n + 1):
+    lat = math.pi * i / n
+    for j in range(n * 2):
+      lon = math.tau * j / (n * 2)
+      x = math.sin(lat) * math.cos(lon)
+      y = math.cos(lat)
+      z = math.sin(lat) * math.sin(lon)
+      verts.append((x * radius, y * radius, z * radius))
+      norms.append((x, y, z))
+  w = n * 2
+  faces = []
+  for i in range(n):
+    for j in range(w):
+      a = i * w + j
+      b = a + 1 if j < w - 1 else i * w
+      c = a + w
+      d = c + 1 if j < w - 1 else (i + 1) * w
+      faces.extend([3, a, b, c, 3, b, d, c])
+  nv = len(verts)
+  verts_np = np.array(verts, dtype=np.float32)
+  norms_np = np.array(norms, dtype=np.float32)
+  up = np.array([0, 1, 0], dtype=np.float32)
+  binormals_np = np.cross(norms_np, up)
+  degen = np.linalg.norm(binormals_np, axis=1) < 1e-6
+  binormals_np[degen] = np.cross(norms_np[degen], [1, 0, 0])
+  lens = np.linalg.norm(binormals_np, axis=1, keepdims=True)
+  binormals_np = binormals_np / np.where(lens < 1e-10, 1.0, lens)
+  return verts_np, norms_np, binormals_np, faces
+
+################################################################################
+
+# Solid colors to cycle through in mode 1 (linear PBR space).
+SOLID_PALETTE = [
+  vec3(0.15, 0.15, 0.15),  # neutral gray
+  vec3(0.18, 0.06, 0.06),  # crimson
+  vec3(0.06, 0.16, 0.08),  # forest
+  vec3(0.06, 0.10, 0.20),  # navy
+  vec3(0.20, 0.18, 0.06),  # warm yellow
+]
+
+# Static "sky to ground" stops for mode 2. Zenith is kept fairly bright so
+# the silhouette-top of chrome spheres (which samples V_tex near 0) reads as
+# sky, not as a dark cap.
+STATIC_GRADIENT = [
+  (0.00, vec3(0.22, 0.30, 0.52)),
+  (0.48, vec3(0.32, 0.46, 0.72)),
+  (0.52, vec3(0.40, 0.40, 0.42)),
+  (1.00, vec3(0.06, 0.06, 0.07)),
+]
+
+################################################################################
+
+class ProceduralEnvmapsApp(object):
+
+  def __init__(self):
+    super().__init__()
+    self.ezapp = lev2.OrkEzApp.create(self, width=1280, height=720)
+    self.ezapp.setRefreshPolicy(lev2.RefreshFastest, 0)
+    setupUiCamera(app=self, eye=vec3(0, 4, 14), tgt=vec3(0, 1, 0))
+    signal.signal(signal.SIGINT, lambda s, f: self.ezapp.signalExit())
+    self.time = 0.0
+    self.mode = 2                # default: static gradient
+    self.solid_idx = 0
+    self.last_radiance_key = None
+    self.pending_radiance = None  # 1-frame defer to avoid pink-flash from
+                                  # not-yet-uploaded textures (Vulkan one-shot
+                                  # transfers drain at the next frame begin)
+
+  ##############################################
+
+  def onGpuInit(self, ctx):
+    createSceneGraph(app=self, params_dict={
+      # Some skybox path is required by the scenegraph init; it loads, then we
+      # immediately replace pbr_common.RadianceMaps with a procedural one.
+      "SkyboxTexPathStr": "ork_envmaps|tozenv_basic",
+      "SkyboxIntensity":  float(1),
+    })
+
+    white_img  = lev2.Image.createFromFile("src://effect_textures/white.dds")
+    normal_img = lev2.Image.createFromFile("src://effect_textures/default_normal.dds")
+
+    verts_np, norms_np, binormals_np, faces = make_sphere_arrays(radius=0.7, n=16)
+    nv = len(verts_np)
+
+    self.material_keep_alive = []
+    self.prim_keep_alive     = []  # RigidPrimitive holds the GPU cluster data;
+                                   # if it's GC'd, render dereferences null
+    self.nodes = []
+
+    # Two rows: top row metallic=1 (mirror→matte sweep), bottom row metallic=0
+    # (dielectric, lit primarily by the diffuse irradiance map).
+    cols     = 9
+    spacing  = 1.6
+    start_x  = -(cols - 1) * spacing / 2.0
+    rows = [
+      ("metal",    1.0, 1.4),  # y = 1.4
+      ("dielect",  0.0, 0.0),  # y = 0.0
+    ]
+    for row_name, metallic, y_off in rows:
+      for i in range(cols):
+        roughness = i / (cols - 1)
+        # Bright neutral-tan vertex color so both reflection and diffuse read
+        # well against any envmap; (B, G, R, A) ordering for the MicroMesh
+        # ARGBU32 packing convention used elsewhere in these tests.
+        rgb = (0.85, 0.78, 0.7)
+        colors_np = np.tile(np.array([rgb[2], rgb[1], rgb[0], 1.0],
+                                     dtype=np.float32), (nv, 1))
+
+        mesh = MicroMesh.fromVertAndFaceLists(verts_np, faces)
+        mesh.updateNormals(norms_np)
+        mesh.updateBinormals(binormals_np)
+        mesh.updateColors(colors_np)
+        prim = RigidPrimitive()
+        prim.updateWithMicroMesh(mesh, ctx, tokens.TRIANGLES)
+
+        mtl = lev2.PBRMaterial()
+        mtl.assignImages(ctx, color=white_img, normal=normal_img,
+                         mtlruf=white_img, doConform=True)
+        mtl.baseColor      = vec4(1, 1, 1, 1)
+        mtl.roughnessFactor = roughness
+        mtl.metallicFactor  = metallic
+        mtl.gpuInit(ctx)
+        self.material_keep_alive.append(mtl)
+
+        node = prim.createNode(f"sphere_{row_name}_{i}", self.layer1, mtl)
+        node.worldTransform.translation = vec3(start_x + i * spacing, 1.0 + y_off, 0)
+        node.sortkey = 10
+        self.prim_keep_alive.append(prim)
+        self.nodes.append(node)
+
+    # Simple key light so dielectrics don't go fully black if envmap is dim.
+    self.point_light = lev2.DynamicPointLight()
+    self.point_light.data.color     = vec3(1, 0.95, 0.85)
+    self.point_light.data.intensity = 4.0
+    self.point_light.data.radius    = 30.0
+    self.light_node = self.layer1.createLightNode("key", self.point_light)
+    self.light_node.setMatrix(mtx4.transMatrix(vec3(3, 5, 5)))
+
+    self.scene.lightingmanager.gpuInit(ctx)
+
+    self.pbr_common = self.scene.pbr_common
+    self.pbr_common.skyboxLevel = 1.0
+
+    print("Procedural envmaps test:")
+    print("  1: solid color (cycles through palette on each press)")
+    print("  2: static gradient (sky / horizon / ground)")
+    print("  3: time-varying gradient (day-to-night cycle)")
+
+  ##############################################
+
+  def _build_radiance_for_mode(self, ctx):
+    """Return (radiance_maps, key) for the current mode and time."""
+    if self.mode == 1:
+      color = SOLID_PALETTE[self.solid_idx % len(SOLID_PALETTE)]
+      key   = ("solid", self.solid_idx)
+      return lev2.PbrCommon.makeRadianceMapsSolidColor(color, ctx), key
+
+    if self.mode == 2:
+      key = ("gradient_static",)
+      return lev2.PbrCommon.makeRadianceMapsGradient(STATIC_GRADIENT, ctx), key
+
+    # mode 3: continuous day-to-night cycle. Quantize the key to the current
+    # time bucket so we rebuild every frame.
+    t = self.time
+    cycle = (math.sin(t * 0.4) + 1.0) * 0.5  # 0 = night, 1 = day
+    sky_top    = vec3(0.02 + 0.20 * cycle, 0.03 + 0.28 * cycle, 0.06 + 0.45 * cycle)
+    sky_horiz  = vec3(0.05 + 0.40 * cycle, 0.08 + 0.45 * cycle, 0.10 + 0.55 * cycle)
+    horizon_lo = vec3(0.05 + 0.30 * cycle, 0.05 + 0.30 * cycle, 0.05 + 0.30 * cycle)
+    nadir      = vec3(0.02 + 0.05 * cycle, 0.02 + 0.05 * cycle, 0.02 + 0.05 * cycle)
+    stops = [
+      (0.00, sky_top),
+      (0.48, sky_horiz),
+      (0.52, horizon_lo),
+      (1.00, nadir),
+    ]
+    return lev2.PbrCommon.makeRadianceMapsGradient(stops, ctx), ("gradient_time", round(t * 60))
+
+  ##############################################
+
+  def onGpuUpdate(self, ctx):
+    # Swap in last frame's pending maps now that their upload one-shot has
+    # been drained at the start of this frame.
+    if self.pending_radiance is not None:
+      self.pbr_common.RadianceMaps = self.pending_radiance
+      self.pending_radiance = None
+
+    rmaps, key = self._build_radiance_for_mode(ctx)
+    if key != self.last_radiance_key:
+      self.last_radiance_key = key
+      self.pending_radiance  = rmaps
+
+  ##############################################
+
+  def onUiEvent(self, uievent):
+    if uievent.code == tokens.KEY_DOWN.hashed:
+      kc = uievent.keycode
+      if kc == ord("1"):
+        if self.mode == 1:
+          self.solid_idx = (self.solid_idx + 1) % len(SOLID_PALETTE)
+        else:
+          self.mode = 1
+        return lev2.ui.HandlerResult()
+      if kc == ord("2"):
+        self.mode = 2
+        return lev2.ui.HandlerResult()
+      if kc == ord("3"):
+        self.mode = 3
+        return lev2.ui.HandlerResult()
+    handled = self.uicam.uiEventHandler(uievent)
+    if handled:
+      self.camera.copyFrom(self.uicam.cameradata)
+    return lev2.ui.HandlerResult()
+
+  def onUpdate(self, updinfo):
+    self.time = updinfo.absolutetime
+    self.scene.updateScene(self.cameralut)
+
+################################################################################
+
+if __name__ == "__main__":
+  app = ProceduralEnvmapsApp()
+  app.ezapp.mainThreadLoop()

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
@@ -121,12 +121,7 @@ class ProceduralEnvmapsApp(object):
                                    # if it's GC'd, render dereferences null
     self.nodes = []
 
-    # 9×9 grid mirroring scenegraph/shaderballs.py.
-    #   X axis (ix): metallic 0 → 1
-    #   Z axis (iz): roughness 0 → 1
-    # Random colors per sphere via HSV. Camera looks down at the grid so
-    # both top-of-sphere (sky reflection) and front-of-sphere (horizon) are
-    # visible at all (metallic, roughness) combinations.
+    # 9×9 grid: X axis = metallic 0→1, Z axis = roughness 0→1, random HSV color.
     grid_n   = 9
     spacing  = 1.8
     origin   = -(grid_n - 1) * spacing / 2.0
@@ -136,7 +131,6 @@ class ProceduralEnvmapsApp(object):
         metallic  = ix / float(grid_n - 1)
         roughness = iz / float(grid_n - 1)
 
-        # HSV → RGB random base color (matches shaderballs convention).
         h = random.uniform(0, 1)
         s = random.uniform(0, 0.7)
         v = random.uniform(0.4, 1.0)
@@ -182,8 +176,7 @@ class ProceduralEnvmapsApp(object):
     self.pbr_common = self.scene.pbr_common
     self.pbr_common.skyboxLevel = 1.0
 
-    # One procedural radiance maps, reused across all modes via the update*
-    # functions — no texture-object churn so mode 3 can rebuild every frame.
+    # One radiance maps object, mutated in place by all modes.
     self.proc_radiance = lev2.PbrCommon.makeProceduralRadianceMaps(ctx)
     lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, STATIC_GRADIENT, ctx)
     self.pbr_common.RadianceMaps = self.proc_radiance
@@ -212,24 +205,20 @@ class ProceduralEnvmapsApp(object):
   ##############################################
 
   def onGpuUpdate(self, ctx):
-    # Repopulate the shared radiance maps in place. No new textures are
-    # allocated — the underlying VkImage / TextureArray slices are reused,
-    # so descriptor-set cache entries stay valid forever.
-    if self.mode == 1:
-      key = ("solid", self.solid_idx)
-      if key != self.last_radiance_key:
-        self.last_radiance_key = key
-        color = SOLID_PALETTE[self.solid_idx % len(SOLID_PALETTE)]
-        lev2.PbrCommon.updateRadianceMapsSolidColor(self.proc_radiance, color, ctx)
-    elif self.mode == 2:
-      key = ("gradient_static",)
-      if key != self.last_radiance_key:
-        self.last_radiance_key = key
-        lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, STATIC_GRADIENT, ctx)
-    else:  # mode 3 — rebuild every frame, no leak
+    if self.mode == 3:
       stops = self._stops_for_time(self.time)
       lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, stops, ctx)
       self.last_radiance_key = ("gradient_time",)
+      return
+    key = ("solid", self.solid_idx) if self.mode == 1 else ("gradient_static",)
+    if key == self.last_radiance_key:
+      return
+    self.last_radiance_key = key
+    if self.mode == 1:
+      color = SOLID_PALETTE[self.solid_idx % len(SOLID_PALETTE)]
+      lev2.PbrCommon.updateRadianceMapsSolidColor(self.proc_radiance, color, ctx)
+    else:
+      lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, STATIC_GRADIENT, ctx)
 
   ##############################################
 

--- a/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
+++ b/ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py
@@ -9,16 +9,17 @@
 # Press 2: static vertical gradient (sky / horizon / ground).
 # Press 3: time-varying gradient (day-to-night cycle, rebuilt every frame).
 #
-# A row of 9 spheres sweeps roughness 0→1 at metallic=1, plus an extra row at
-# metallic=0, so reflections and diffuse irradiance are both visible against
-# whichever envmap is active.
+# Layout follows scenegraph/shaderballs.py: a 9×9 grid on the floor where the
+# X axis sweeps metallic 0→1 and the Z axis sweeps roughness 0→1, with random
+# colors per sphere. Lets you see the full PBR matrix against the procedural
+# envmap.
 #
 # Copyright 1996-2023, Michael T. Mayers.
 # Distributed under the MIT License
 # see license-mit.txt in the root of the repo, and/or https://opensource.org/license/mit/
 ################################################################################
 
-import math, sys, signal
+import math, sys, signal, random, colorsys
 import numpy as np
 from orkengine.core import vec3, vec4, quat, mtx4, CrcStringProxy, lev2_pyexdir
 from orkengine import lev2
@@ -92,15 +93,12 @@ class ProceduralEnvmapsApp(object):
     super().__init__()
     self.ezapp = lev2.OrkEzApp.create(self, width=1280, height=720)
     self.ezapp.setRefreshPolicy(lev2.RefreshFastest, 0)
-    setupUiCamera(app=self, eye=vec3(0, 4, 14), tgt=vec3(0, 1, 0))
+    setupUiCamera(app=self, eye=vec3(0, 12, 18), tgt=vec3(0, 1, 0))
     signal.signal(signal.SIGINT, lambda s, f: self.ezapp.signalExit())
     self.time = 0.0
-    self.mode = 2                # default: static gradient
+    self.mode = 2  # default: static gradient
     self.solid_idx = 0
     self.last_radiance_key = None
-    self.pending_radiance = None  # 1-frame defer to avoid pink-flash from
-                                  # not-yet-uploaded textures (Vulkan one-shot
-                                  # transfers drain at the next frame begin)
 
   ##############################################
 
@@ -123,23 +121,28 @@ class ProceduralEnvmapsApp(object):
                                    # if it's GC'd, render dereferences null
     self.nodes = []
 
-    # Two rows: top row metallic=1 (mirror→matte sweep), bottom row metallic=0
-    # (dielectric, lit primarily by the diffuse irradiance map).
-    cols     = 9
-    spacing  = 1.6
-    start_x  = -(cols - 1) * spacing / 2.0
-    rows = [
-      ("metal",    1.0, 1.4),  # y = 1.4
-      ("dielect",  0.0, 0.0),  # y = 0.0
-    ]
-    for row_name, metallic, y_off in rows:
-      for i in range(cols):
-        roughness = i / (cols - 1)
-        # Bright neutral-tan vertex color so both reflection and diffuse read
-        # well against any envmap; (B, G, R, A) ordering for the MicroMesh
-        # ARGBU32 packing convention used elsewhere in these tests.
-        rgb = (0.85, 0.78, 0.7)
-        colors_np = np.tile(np.array([rgb[2], rgb[1], rgb[0], 1.0],
+    # 9×9 grid mirroring scenegraph/shaderballs.py.
+    #   X axis (ix): metallic 0 → 1
+    #   Z axis (iz): roughness 0 → 1
+    # Random colors per sphere via HSV. Camera looks down at the grid so
+    # both top-of-sphere (sky reflection) and front-of-sphere (horizon) are
+    # visible at all (metallic, roughness) combinations.
+    grid_n   = 9
+    spacing  = 1.8
+    origin   = -(grid_n - 1) * spacing / 2.0
+    random.seed(12)
+    for ix in range(grid_n):
+      for iz in range(grid_n):
+        metallic  = ix / float(grid_n - 1)
+        roughness = iz / float(grid_n - 1)
+
+        # HSV → RGB random base color (matches shaderballs convention).
+        h = random.uniform(0, 1)
+        s = random.uniform(0, 0.7)
+        v = random.uniform(0.4, 1.0)
+        r, g, b = colorsys.hsv_to_rgb(h, s, v)
+        # BGRA pre-swap for MicroMesh's ARGBU32 packing convention.
+        colors_np = np.tile(np.array([b, g, r, 1.0],
                                      dtype=np.float32), (nv, 1))
 
         mesh = MicroMesh.fromVertAndFaceLists(verts_np, faces)
@@ -152,14 +155,16 @@ class ProceduralEnvmapsApp(object):
         mtl = lev2.PBRMaterial()
         mtl.assignImages(ctx, color=white_img, normal=normal_img,
                          mtlruf=white_img, doConform=True)
-        mtl.baseColor      = vec4(1, 1, 1, 1)
+        mtl.baseColor       = vec4(1, 1, 1, 1)
         mtl.roughnessFactor = roughness
         mtl.metallicFactor  = metallic
         mtl.gpuInit(ctx)
         self.material_keep_alive.append(mtl)
 
-        node = prim.createNode(f"sphere_{row_name}_{i}", self.layer1, mtl)
-        node.worldTransform.translation = vec3(start_x + i * spacing, 1.0 + y_off, 0)
+        node = prim.createNode(f"sphere_{ix}_{iz}", self.layer1, mtl)
+        node.worldTransform.translation = vec3(origin + ix * spacing,
+                                               1.0,
+                                               origin + iz * spacing)
         node.sortkey = 10
         self.prim_keep_alive.append(prim)
         self.nodes.append(node)
@@ -177,53 +182,54 @@ class ProceduralEnvmapsApp(object):
     self.pbr_common = self.scene.pbr_common
     self.pbr_common.skyboxLevel = 1.0
 
-    print("Procedural envmaps test:")
+    # One procedural radiance maps, reused across all modes via the update*
+    # functions — no texture-object churn so mode 3 can rebuild every frame.
+    self.proc_radiance = lev2.PbrCommon.makeProceduralRadianceMaps(ctx)
+    lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, STATIC_GRADIENT, ctx)
+    self.pbr_common.RadianceMaps = self.proc_radiance
+
+    print("Procedural envmaps test (9×9 grid: X=metallic, Z=roughness):")
     print("  1: solid color (cycles through palette on each press)")
     print("  2: static gradient (sky / horizon / ground)")
     print("  3: time-varying gradient (day-to-night cycle)")
 
   ##############################################
 
-  def _build_radiance_for_mode(self, ctx):
-    """Return (radiance_maps, key) for the current mode and time."""
-    if self.mode == 1:
-      color = SOLID_PALETTE[self.solid_idx % len(SOLID_PALETTE)]
-      key   = ("solid", self.solid_idx)
-      return lev2.PbrCommon.makeRadianceMapsSolidColor(color, ctx), key
-
-    if self.mode == 2:
-      key = ("gradient_static",)
-      return lev2.PbrCommon.makeRadianceMapsGradient(STATIC_GRADIENT, ctx), key
-
-    # mode 3: continuous day-to-night cycle. Quantize the key to the current
-    # time bucket so we rebuild every frame.
-    t = self.time
+  def _stops_for_time(self, t):
+    """Day-to-night cycle gradient stops for mode 3."""
     cycle = (math.sin(t * 0.4) + 1.0) * 0.5  # 0 = night, 1 = day
     sky_top    = vec3(0.02 + 0.20 * cycle, 0.03 + 0.28 * cycle, 0.06 + 0.45 * cycle)
     sky_horiz  = vec3(0.05 + 0.40 * cycle, 0.08 + 0.45 * cycle, 0.10 + 0.55 * cycle)
     horizon_lo = vec3(0.05 + 0.30 * cycle, 0.05 + 0.30 * cycle, 0.05 + 0.30 * cycle)
     nadir      = vec3(0.02 + 0.05 * cycle, 0.02 + 0.05 * cycle, 0.02 + 0.05 * cycle)
-    stops = [
+    return [
       (0.00, sky_top),
       (0.48, sky_horiz),
       (0.52, horizon_lo),
       (1.00, nadir),
     ]
-    return lev2.PbrCommon.makeRadianceMapsGradient(stops, ctx), ("gradient_time", round(t * 60))
 
   ##############################################
 
   def onGpuUpdate(self, ctx):
-    # Swap in last frame's pending maps now that their upload one-shot has
-    # been drained at the start of this frame.
-    if self.pending_radiance is not None:
-      self.pbr_common.RadianceMaps = self.pending_radiance
-      self.pending_radiance = None
-
-    rmaps, key = self._build_radiance_for_mode(ctx)
-    if key != self.last_radiance_key:
-      self.last_radiance_key = key
-      self.pending_radiance  = rmaps
+    # Repopulate the shared radiance maps in place. No new textures are
+    # allocated — the underlying VkImage / TextureArray slices are reused,
+    # so descriptor-set cache entries stay valid forever.
+    if self.mode == 1:
+      key = ("solid", self.solid_idx)
+      if key != self.last_radiance_key:
+        self.last_radiance_key = key
+        color = SOLID_PALETTE[self.solid_idx % len(SOLID_PALETTE)]
+        lev2.PbrCommon.updateRadianceMapsSolidColor(self.proc_radiance, color, ctx)
+    elif self.mode == 2:
+      key = ("gradient_static",)
+      if key != self.last_radiance_key:
+        self.last_radiance_key = key
+        lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, STATIC_GRADIENT, ctx)
+    else:  # mode 3 — rebuild every frame, no leak
+      stops = self._stops_for_time(self.time)
+      lev2.PbrCommon.updateRadianceMapsGradient(self.proc_radiance, stops, ctx)
+      self.last_radiance_key = ("gradient_time",)
 
   ##############################################
 

--- a/ork.lev2/src/gfx/radiancemaps_asset.cpp
+++ b/ork.lev2/src/gfx/radiancemaps_asset.cpp
@@ -155,12 +155,18 @@ asset::asset_ptr_t RadianceMapsLoader::_loadFromXIR(
         diffuse_loadreq->_cmipchain = diffuse_cmipchain;
         diffuse_loadreq->_texname = base_name + ".irrdiff";
         ctx->TXI()->_createFromLoadReq(diffuse_loadreq);
+        // Equirectangular: U wraps (longitude seam), V clamps (no pole bleed
+        // across the wraparound when bilinear filtering at V=0 / V=1).
+        diffuse_tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
+        diffuse_tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
+        diffuse_tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
+        ctx->TXI()->ApplySamplingMode(diffuse_tex.get());
         irrmaps->_filtenvDiffuseMap = diffuse_tex;
       };
       GfxEnv::GetRef().enqueueDeferredContextOp(diffuseUploadOp);
     }
     //diffuseUploadOp(gloadercontext.get());
-      
+
     //////////////////////////////////////////////////////////////
     // init texture array op (deferrable)
     //////////////////////////////////////////////////////////////
@@ -175,6 +181,10 @@ asset::asset_ptr_t RadianceMapsLoader::_loadFromXIR(
         TID._slices[i] = TextureArrayInitSubItem{usage_id, specular_images[i]};
       }
       txi->initTextureArray2DFromData(specular_texarray.get(), TID);
+      specular_texarray->_tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
+      specular_texarray->_tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
+      specular_texarray->_tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
+      txi->ApplySamplingMode(specular_texarray->_tex.get());
       irrmaps->_filtenvSpecularMapArray = specular_texarray;  // Use array instead of single texture
     };
 

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
@@ -292,16 +292,6 @@ radiancemaps_ptr_t CommonStuff::makeProceduralRadianceMaps(Context* ctx) {
   return maps;
 }
 
-void CommonStuff::updateRadianceMapsSolidColor(
-    radiancemaps_ptr_t maps, fvec3 color, Context* ctx) {
-  OrkAssert(maps && maps->_filtenvSpecularMapArray);
-  int W = int(maps->_filtenvSpecularMapArray->_width);
-  int H = int(maps->_filtenvSpecularMapArray->_height);
-  auto img = buildRowwiseImage(W, H, [color](float) { return color; });
-  std::vector<image_ptr_t> spec(maps->_numRoughnessLevels, img);
-  uploadRadianceMapsImages(maps, spec, img, ctx);
-}
-
 void CommonStuff::updateRadianceMapsGradient(
     radiancemaps_ptr_t maps,
     const std::vector<std::pair<float, fvec3>>& stops,

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
@@ -298,8 +298,8 @@ radiancemaps_ptr_t CommonStuff::makeRadianceMapsGradient(
 
   constexpr int kNumRoughnessLevels = 10;
   constexpr float kRoughnessPower   = 0.5f;
-  constexpr int kEnvW               = 16;
-  constexpr int kEnvH               = 32;
+  constexpr int kEnvW               = 32;
+  constexpr int kEnvH               = 64;
 
   auto irrmaps                  = std::make_shared<RadianceMaps>();
   irrmaps->_numRoughnessLevels  = kNumRoughnessLevels;
@@ -328,17 +328,18 @@ radiancemaps_ptr_t CommonStuff::makeRadianceMapsGradient(
     TID._slices[i]    = TextureArrayInitSubItem{usage_id, spec_images[i]};
   }
   txi->initTextureArray2DFromData(specular_arr.get(), TID);
-  // Default sampling (WRAP on all axes) matches the disk-loaded envmap path.
-  // The runtime PBR shader does textureLod(envtex, vec2(-uv.x, -uv.y), ...);
-  // under WRAP, fract(-V) acts as a mirror that lands on the right row for
-  // every fragment except the literal pole — same shared artifact as disk.
+  // Equirectangular: U wraps (longitude seam), V clamps (no pole bleed
+  // across the wraparound when bilinear filtering at V=0 / V=1). Pairs with
+  // the envtools.i2 sampling using `1.0 - uv.y` instead of `-uv.y`.
+  specular_arr->_tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
+  specular_arr->_tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
+  specular_arr->_tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
+  txi->ApplySamplingMode(specular_arr->_tex.get());
   irrmaps->_filtenvSpecularMapArray = specular_arr;
 
   // Diffuse: per-row directional irradiance. The disk diffuse baker stores
-  // E for normal-DOWN at texel V=0 and normal-UP at V=1 (its UV2N path
-  // applies n = n * (-1,-1,1) which inverts the V-to-theta mapping). We
-  // mirror that convention so the runtime sampler reads the correct row
-  // for any given world-space surface normal.
+  // E for normal-DOWN at texel V=0 and normal-UP at V=1; we match that
+  // convention.
   auto diffuse_image                = std::make_shared<Image>();
   diffuse_image->_format            = EBufferFormat::RGB8;
   diffuse_image->_bytesPerChannel   = 1;
@@ -361,6 +362,10 @@ radiancemaps_ptr_t CommonStuff::makeRadianceMapsGradient(
   auto diffuse_tex        = std::make_shared<Texture>();
   diffuse_tex->_debugName = "procGradDiff";
   txi->initTextureFromImage(diffuse_tex.get(), diffuse_image, false, false);
+  diffuse_tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
+  diffuse_tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
+  diffuse_tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
+  txi->ApplySamplingMode(diffuse_tex.get());
   irrmaps->_filtenvDiffuseMap = diffuse_tex;
 
   irrmaps->_brdfIntegrationMapGGX    = PBRMaterial::brdfIntegrationMap(ctx, "GGX");

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
@@ -152,6 +152,9 @@ radiancemaps_ptr_t CommonStuff::requestRadianceMapsSync(const AssetPath& texture
 
 namespace {
 
+// Gradient envs are rotation-symmetric about Y, so W only needs to be wide enough for
+// stable bilinear filtering; H resolves the latitude gradient. Roughness curve matches
+// the disk-IBL bake convention in radiancemaps_processor.cpp.
 constexpr int   kProcNumRoughnessLevels = 10;
 constexpr float kProcRoughnessPower     = 0.5f;
 constexpr int   kProcEnvW               = 32;
@@ -182,30 +185,6 @@ fvec3 sphereAverage(const std::vector<std::pair<float, fvec3>>& stops, int n = 6
   return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0);
 }
 
-// Cosine-weighted hemisphere integral E(n) = (1/π) ∫ L(ω) max(0, n·ω) dω,
-// for a surface normal at polar angle theta_n. Rotation-symmetric env so the
-// result depends only on theta_n.
-fvec3 directionalDiffuse(const std::vector<std::pair<float, fvec3>>& stops, float theta_n) {
-  float nx = sinf(theta_n), ny = cosf(theta_n);
-  fvec3 acc(0); float w_sum = 0.0f;
-  constexpr int kT = 32, kP = 32;
-  for (int it = 0; it < kT; ++it) {
-    float theta_w = (float(it) + 0.5f) / float(kT) * float(PI);
-    float cy = cosf(theta_w), cx = sinf(theta_w);
-    fvec3 L = sampleGradientAt(stops, theta_w / float(PI));
-    for (int ip = 0; ip < kP; ++ip) {
-      float phi = (float(ip) + 0.5f) / float(kP) * 2.0f * float(PI);
-      float dot = nx * (cx * cosf(phi)) + ny * cy;
-      if (dot > 0.0f) {
-        float w = dot * cx;
-        acc   = acc + L * w;
-        w_sum = w_sum + w;
-      }
-    }
-  }
-  return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0);
-}
-
 // RGBA32F image filled with a per-row color via `row_color(v)`.
 template<typename F>
 image_ptr_t buildRowwiseImage(int w, int h, F&& row_color) {
@@ -223,6 +202,51 @@ image_ptr_t buildRowwiseImage(int w, int h, F&& row_color) {
     }
   }
   return img;
+}
+
+// Cosine-weighted hemisphere integral E(n) = (1/π) ∫ L(ω) max(0, n·ω) dω,
+// rasterized into an RGBA32F image (row index ↔ surface normal polar angle).
+// The cosine kernel only depends on (theta_n, theta_w), so we precompute a
+// per-row × per-theta_w table once via a Meyers singleton and per-call work
+// collapses to a length-kT dot product per row.
+image_ptr_t buildDiffuseImage(
+    const std::vector<std::pair<float, fvec3>>& stops, int W, int H) {
+  OrkAssert(H == kProcEnvH);
+  constexpr int kT = 32, kP = 32;
+  struct Kernel { float w[kProcEnvH][kT]; float inv_sum[kProcEnvH]; };
+  static const Kernel kernel = [] {
+    Kernel out{};
+    for (int row = 0; row < kProcEnvH; ++row) {
+      float v_row   = float(row) / float(kProcEnvH - 1);
+      float theta_n = (1.0f - v_row) * float(PI);    // V=0 → down, V=1 → up
+      float nx = sinf(theta_n), ny = cosf(theta_n);
+      float w_sum = 0.0f;
+      for (int it = 0; it < kT; ++it) {
+        float theta_w = (float(it) + 0.5f) / float(kT) * float(PI);
+        float cy = cosf(theta_w), cx = sinf(theta_w);
+        float s = 0.0f;
+        for (int ip = 0; ip < kP; ++ip) {
+          float phi = (float(ip) + 0.5f) / float(kP) * 2.0f * float(PI);
+          float dot = nx * (cx * cosf(phi)) + ny * cy;
+          if (dot > 0.0f) { float w = dot * cx; s += w; w_sum += w; }
+        }
+        out.w[row][it] = s;
+      }
+      out.inv_sum[row] = (w_sum > 0.0f) ? 1.0f / w_sum : 0.0f;
+    }
+    return out;
+  }();
+
+  fvec3 L_table[kT];
+  for (int it = 0; it < kT; ++it)
+    L_table[it] = sampleGradientAt(stops, (float(it) + 0.5f) / float(kT));
+
+  return buildRowwiseImage(W, H, [&](float v) {
+    int row = int(v * (H - 1) + 0.5f);
+    fvec3 acc(0);
+    for (int it = 0; it < kT; ++it) acc = acc + L_table[it] * kernel.w[row][it];
+    return acc * kernel.inv_sum[row];
+  });
 }
 
 // In-place upload — reuses VkImage / TextureArray slices, no descriptor churn.
@@ -303,8 +327,8 @@ void CommonStuff::updateRadianceMapsGradient(
   fvec3 avg = sphereAverage(stops);
 
   // Specular slices: gradient at V, lerped toward sphere-average by the
-  // slice's roughness. Diffuse: per-row directional irradiance, V-flipped to
-  // match the disk diffuse baker convention (V=0 → down, V=1 → up).
+  // slice's roughness. Diffuse: per-row directional irradiance via the
+  // factored hemisphere integral in buildDiffuseImage.
   std::vector<image_ptr_t> spec;
   spec.reserve(maps->_specularRoughnessValues.size());
   for (float r : maps->_specularRoughnessValues) {
@@ -313,9 +337,7 @@ void CommonStuff::updateRadianceMapsGradient(
       return c * (1.0f - r) + avg * r;
     }));
   }
-  auto diff = buildRowwiseImage(W, H, [&](float v) {
-    return directionalDiffuse(stops, (1.0f - v) * float(PI));
-  });
+  auto diff = buildDiffuseImage(stops, W, H);
   uploadRadianceMapsImages(maps, spec, diff, ctx);
 }
 

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
@@ -206,31 +206,26 @@ fvec3 directionalDiffuse(const std::vector<std::pair<float, fvec3>>& stops, floa
   return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0);
 }
 
-// Image filled with a per-row color via `row_color(v)`.
+// RGBA32F image filled with a per-row color via `row_color(v)`.
 template<typename F>
 image_ptr_t buildRowwiseImage(int w, int h, F&& row_color) {
   auto img              = std::make_shared<Image>();
-  img->_format          = EBufferFormat::RGB8;
-  img->_bytesPerChannel = 1;
-  img->init(w, h, 3, 1);
-  auto p = (uint8_t*)img->_data->data();
+  img->_format          = EBufferFormat::RGBA32F;
+  img->_bytesPerChannel = 4;
+  img->init(w, h, 4, 4);
+  auto p = (float*)img->_data->data();
   for (int y = 0; y < h; ++y) {
     float v = (h > 1) ? float(y) / float(h - 1) : 0.0f;
-    fvec3  c = row_color(v);
-    uint8_t r = uint8_t(std::clamp(c.x, 0.0f, 1.0f) * 255.0f);
-    uint8_t g = uint8_t(std::clamp(c.y, 0.0f, 1.0f) * 255.0f);
-    uint8_t b = uint8_t(std::clamp(c.z, 0.0f, 1.0f) * 255.0f);
+    fvec3 c = row_color(v);
     for (int x = 0; x < w; ++x) {
-      int idx = (y * w + x) * 3;
-      p[idx + 0] = r; p[idx + 1] = g; p[idx + 2] = b;
+      int idx = (y * w + x) * 4;
+      p[idx + 0] = c.x; p[idx + 1] = c.y; p[idx + 2] = c.z; p[idx + 3] = 1.0f;
     }
   }
   return img;
 }
 
-// Uploads in-place: spec slices via updateTextureArraySlice (no
-// VulkanTextureObject realloc), diffuse via initTextureFromImage which
-// reuses the VkImage when format matches.
+// In-place upload — reuses VkImage / TextureArray slices, no descriptor churn.
 void uploadRadianceMapsImages(
     radiancemaps_ptr_t maps,
     const std::vector<image_ptr_t>& spec_images,
@@ -258,11 +253,7 @@ radiancemaps_ptr_t CommonStuff::makeProceduralRadianceMaps(Context* ctx) {
         powf(float(i) / float(kProcNumRoughnessLevels - 1), kProcRoughnessPower);
   }
 
-  // Initial allocation — every slice and the diffuse share a single black
-  // image. Subsequent updates use updateTextureArraySlice / initTextureFromImage
-  // on these same texture objects (no descriptor-set churn).
-  auto black = std::make_shared<Image>();
-  black->initRGB8WithColor(kProcEnvW, kProcEnvH, fvec3(0));
+  auto black = buildRowwiseImage(kProcEnvW, kProcEnvH, [](float) { return fvec3(0); });
 
   auto txi          = ctx->TXI();
   auto specular_arr = std::make_shared<TextureArray>();
@@ -274,24 +265,23 @@ radiancemaps_ptr_t CommonStuff::makeProceduralRadianceMaps(Context* ctx) {
     TID._slices[i]    = TextureArrayInitSubItem{usage_id, black};
   }
   txi->initTextureArray2DFromData(specular_arr.get(), TID);
-  // Equirectangular: U wraps, V clamps (no pole bleed at the V=0/V=1
-  // boundaries when bilinear-filtering near the poles).
-  for (auto* tex : {specular_arr->_tex.get()}) {
-    tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
-    tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
-    tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
-    txi->ApplySamplingMode(tex);
-  }
-  maps->_filtenvSpecularMapArray = specular_arr;
 
   auto diffuse_tex        = std::make_shared<Texture>();
   diffuse_tex->_debugName = "procRadDiff";
   txi->initTextureFromImage(diffuse_tex.get(), black, false, false);
-  diffuse_tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
-  diffuse_tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
-  diffuse_tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
-  txi->ApplySamplingMode(diffuse_tex.get());
-  maps->_filtenvDiffuseMap = diffuse_tex;
+
+  // Equirectangular: U wraps, V clamps (no pole bleed at V=0/V=1).
+  auto setEquirectangularSampling = [&](Texture* tex) {
+    tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
+    tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
+    tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
+    txi->ApplySamplingMode(tex);
+  };
+  setEquirectangularSampling(specular_arr->_tex.get());
+  setEquirectangularSampling(diffuse_tex.get());
+
+  maps->_filtenvSpecularMapArray = specular_arr;
+  maps->_filtenvDiffuseMap       = diffuse_tex;
 
   maps->_brdfIntegrationMapGGX    = PBRMaterial::brdfIntegrationMap(ctx, "GGX");
   maps->_brdfIntegrationMapVelvet = PBRMaterial::brdfIntegrationMap(ctx, "GGXVELVET");
@@ -307,8 +297,7 @@ void CommonStuff::updateRadianceMapsSolidColor(
   OrkAssert(maps && maps->_filtenvSpecularMapArray);
   int W = int(maps->_filtenvSpecularMapArray->_width);
   int H = int(maps->_filtenvSpecularMapArray->_height);
-  auto img = std::make_shared<Image>();
-  img->initRGB8WithColor(W, H, color);
+  auto img = buildRowwiseImage(W, H, [color](float) { return color; });
   std::vector<image_ptr_t> spec(maps->_numRoughnessLevels, img);
   uploadRadianceMapsImages(maps, spec, img, ctx);
 }

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
@@ -32,6 +32,8 @@
 
 #include <ork/lev2/gfx/radiancemaps_asset.h>
 #include <ork/lev2/gfx/xir_format.h>
+#include <ork/lev2/gfx/material_pbr.inl>
+#include <ork/lev2/gfx/image.h>
 
 #include <ork/profiling.inl>
 #include <ork/asset/Asset.inl>
@@ -144,6 +146,49 @@ radiancemaps_ptr_t CommonStuff::requestRadianceMapsSync(const AssetPath& texture
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return rm_asset->_radiance_maps;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+radiancemaps_ptr_t CommonStuff::makeRadianceMapsSolidColor(fvec3 color, Context* ctx) {
+  // Match the standard 10-level / pow(i/9, 0.5) layout produced by xir bakes
+  // so shaders and material parameters see a familiar roughness distribution.
+  constexpr int kNumRoughnessLevels = 10;
+  constexpr float kRoughnessPower   = 0.5f;
+  constexpr int kEnvW               = 16;
+  constexpr int kEnvH               = 8;
+
+  auto irrmaps                  = std::make_shared<RadianceMaps>();
+  irrmaps->_numRoughnessLevels  = kNumRoughnessLevels;
+  irrmaps->_specularRoughnessValues.resize(kNumRoughnessLevels);
+  for (int i = 0; i < kNumRoughnessLevels; ++i) {
+    irrmaps->_specularRoughnessValues[i] =
+        powf(float(i) / float(kNumRoughnessLevels - 1), kRoughnessPower);
+  }
+
+  auto txi = ctx->TXI();
+
+  irrmaps->_filtenvSpecularMapArray =
+      txi->createColorTextureV3Array(color, kEnvW, kEnvH, kNumRoughnessLevels);
+  irrmaps->_filtenvSpecularMapArray->_tex->_debugName = "procSolidSpec";
+
+  // NOTE: createColorTextureV3 declares BGR8 but writes RGB-ordered data,
+  // which swaps R and B on the GPU. Build the diffuse map via the
+  // RGB8-correct Image path instead.
+  auto diffuse_image = std::make_shared<Image>();
+  diffuse_image->initRGB8WithColor(kEnvW, kEnvH, color);
+  auto diffuse_tex         = std::make_shared<Texture>();
+  diffuse_tex->_debugName  = "procSolidDiff";
+  txi->initTextureFromImage(diffuse_tex.get(), diffuse_image, false, false);
+  irrmaps->_filtenvDiffuseMap = diffuse_tex;
+
+  irrmaps->_brdfIntegrationMapGGX    = PBRMaterial::brdfIntegrationMap(ctx, "GGX");
+  irrmaps->_brdfIntegrationMapVelvet = PBRMaterial::brdfIntegrationMap(ctx, "GGXVELVET");
+  irrmaps->_brdfIntegrationMapGGXRIM = PBRMaterial::brdfIntegrationMap(ctx, "GGXRIM");
+  irrmaps->_brdfIntegrationMapBlinn  = PBRMaterial::brdfIntegrationMap(ctx, "BLINN");
+  irrmaps->_brdfIntegrationMapPhong  = PBRMaterial::brdfIntegrationMap(ctx, "PHONG");
+
+  return irrmaps;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
@@ -193,6 +193,187 @@ radiancemaps_ptr_t CommonStuff::makeRadianceMapsSolidColor(fvec3 color, Context*
 
 ///////////////////////////////////////////////////////////////////////////////
 
+namespace {
+
+// Linear interpolation between (sorted) gradient stops at parameter t in [0,1].
+fvec3 sampleGradientAt(const std::vector<std::pair<float, fvec3>>& stops, float t) {
+  if (t <= stops.front().first)  return stops.front().second;
+  if (t >= stops.back().first)   return stops.back().second;
+  for (size_t i = 0; i + 1 < stops.size(); ++i) {
+    float t0 = stops[i].first;
+    float t1 = stops[i + 1].first;
+    if (t >= t0 && t <= t1) {
+      float frac = (t1 > t0) ? (t - t0) / (t1 - t0) : 0.0f;
+      return stops[i].second * (1.0f - frac) + stops[i + 1].second * frac;
+    }
+  }
+  return stops.back().second;
+}
+
+// Solid-angle-weighted full-sphere average (used as the lerp target for
+// high-roughness specular slices, which converge toward an isotropic blur).
+fvec3 sphereAverage(const std::vector<std::pair<float, fvec3>>& stops, int n_samples = 64) {
+  fvec3 acc(0, 0, 0);
+  float w_sum = 0.0f;
+  for (int i = 0; i < n_samples; ++i) {
+    float v = (float(i) + 0.5f) / float(n_samples);
+    float w = sinf(v * float(PI));
+    acc   = acc + sampleGradientAt(stops, v) * w;
+    w_sum = w_sum + w;
+  }
+  return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0, 0, 0);
+}
+
+// Directional diffuse irradiance: cosine-weighted hemisphere integral of L(ω)
+// for a surface normal at polar angle theta_n from the up-axis. Because the
+// gradient is rotation-symmetric about the up-axis, the result depends only
+// on theta_n (no longitude variation). This is the standard Lambertian IBL
+// integral: E(n) = (1/π) ∫_hemi L(ω) max(0, n·ω) dω.
+fvec3 directionalDiffuse(
+    const std::vector<std::pair<float, fvec3>>& stops,
+    float theta_n) {
+  // n in the y-x plane, WLOG.
+  float nx = sinf(theta_n);
+  float ny = cosf(theta_n);
+
+  constexpr int kThetaSamples = 32;
+  constexpr int kPhiSamples   = 32;
+
+  fvec3 acc(0, 0, 0);
+  float w_sum = 0.0f;
+  for (int it = 0; it < kThetaSamples; ++it) {
+    float theta_w = (float(it) + 0.5f) / float(kThetaSamples) * float(PI);
+    float cy      = cosf(theta_w);
+    float cx      = sinf(theta_w); // also the solid-angle jacobian
+    fvec3 L       = sampleGradientAt(stops, theta_w / float(PI));
+    for (int ip = 0; ip < kPhiSamples; ++ip) {
+      float phi = (float(ip) + 0.5f) / float(kPhiSamples) * 2.0f * float(PI);
+      float ox  = cx * cosf(phi);
+      float dot = nx * ox + ny * cy;
+      if (dot > 0.0f) {
+        float w = dot * cx;
+        acc     = acc + L * w;
+        w_sum   = w_sum + w;
+      }
+    }
+  }
+  return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0, 0, 0);
+}
+
+// Build an Image where each row's color is the gradient at that V, optionally
+// lerped toward `avg` to simulate roughness-induced blur.
+image_ptr_t buildGradientImage(
+    const std::vector<std::pair<float, fvec3>>& stops,
+    fvec3 avg,
+    float roughness_blend, // 0 = sharp gradient, 1 = uniform avg
+    int w,
+    int h) {
+  auto img             = std::make_shared<Image>();
+  img->_format         = EBufferFormat::RGB8;
+  img->_bytesPerChannel = 1;
+  img->init(w, h, 3, 1);
+  auto outptr = (uint8_t*)img->_data->data();
+  for (int y = 0; y < h; ++y) {
+    float v       = (h > 1) ? float(y) / float(h - 1) : 0.0f;
+    fvec3 c       = sampleGradientAt(stops, v);
+    fvec3 blended = c * (1.0f - roughness_blend) + avg * roughness_blend;
+    uint8_t r     = uint8_t(std::clamp(blended.x, 0.0f, 1.0f) * 255.0f);
+    uint8_t g     = uint8_t(std::clamp(blended.y, 0.0f, 1.0f) * 255.0f);
+    uint8_t b     = uint8_t(std::clamp(blended.z, 0.0f, 1.0f) * 255.0f);
+    for (int x = 0; x < w; ++x) {
+      int idx          = (y * w + x) * 3;
+      outptr[idx + 0]  = r;
+      outptr[idx + 1]  = g;
+      outptr[idx + 2]  = b;
+    }
+  }
+  return img;
+}
+
+} // namespace
+
+radiancemaps_ptr_t CommonStuff::makeRadianceMapsGradient(
+    const std::vector<std::pair<float, fvec3>>& stops, Context* ctx) {
+  OrkAssert(!stops.empty());
+
+  constexpr int kNumRoughnessLevels = 10;
+  constexpr float kRoughnessPower   = 0.5f;
+  constexpr int kEnvW               = 16;
+  constexpr int kEnvH               = 32;
+
+  auto irrmaps                  = std::make_shared<RadianceMaps>();
+  irrmaps->_numRoughnessLevels  = kNumRoughnessLevels;
+  irrmaps->_specularRoughnessValues.resize(kNumRoughnessLevels);
+  for (int i = 0; i < kNumRoughnessLevels; ++i) {
+    irrmaps->_specularRoughnessValues[i] =
+        powf(float(i) / float(kNumRoughnessLevels - 1), kRoughnessPower);
+  }
+
+  fvec3 avg = sphereAverage(stops);
+
+  std::vector<image_ptr_t> spec_images;
+  spec_images.reserve(kNumRoughnessLevels);
+  for (int i = 0; i < kNumRoughnessLevels; ++i) {
+    float r = irrmaps->_specularRoughnessValues[i];
+    spec_images.push_back(buildGradientImage(stops, avg, r, kEnvW, kEnvH));
+  }
+
+  auto txi          = ctx->TXI();
+  auto specular_arr = std::make_shared<TextureArray>();
+  specular_arr->_tex->_debugName = "procGradSpec";
+  TextureArrayInitData TID;
+  TID._slices.resize(kNumRoughnessLevels);
+  for (int i = 0; i < kNumRoughnessLevels; ++i) {
+    uint32_t usage_id = CrcString(FormatString("roughness_%d", i).c_str()).hashed();
+    TID._slices[i]    = TextureArrayInitSubItem{usage_id, spec_images[i]};
+  }
+  txi->initTextureArray2DFromData(specular_arr.get(), TID);
+  // Default sampling (WRAP on all axes) matches the disk-loaded envmap path.
+  // The runtime PBR shader does textureLod(envtex, vec2(-uv.x, -uv.y), ...);
+  // under WRAP, fract(-V) acts as a mirror that lands on the right row for
+  // every fragment except the literal pole — same shared artifact as disk.
+  irrmaps->_filtenvSpecularMapArray = specular_arr;
+
+  // Diffuse: per-row directional irradiance. The disk diffuse baker stores
+  // E for normal-DOWN at texel V=0 and normal-UP at V=1 (its UV2N path
+  // applies n = n * (-1,-1,1) which inverts the V-to-theta mapping). We
+  // mirror that convention so the runtime sampler reads the correct row
+  // for any given world-space surface normal.
+  auto diffuse_image                = std::make_shared<Image>();
+  diffuse_image->_format            = EBufferFormat::RGB8;
+  diffuse_image->_bytesPerChannel   = 1;
+  diffuse_image->init(kEnvW, kEnvH, 3, 1);
+  auto diff_ptr = (uint8_t*)diffuse_image->_data->data();
+  for (int y = 0; y < kEnvH; ++y) {
+    float v       = (kEnvH > 1) ? float(y) / float(kEnvH - 1) : 0.0f;
+    float theta_n = (1.0f - v) * float(PI);  // V=0 → down, V=1 → up
+    fvec3 c       = directionalDiffuse(stops, theta_n);
+    uint8_t r     = uint8_t(std::clamp(c.x, 0.0f, 1.0f) * 255.0f);
+    uint8_t g     = uint8_t(std::clamp(c.y, 0.0f, 1.0f) * 255.0f);
+    uint8_t b     = uint8_t(std::clamp(c.z, 0.0f, 1.0f) * 255.0f);
+    for (int x = 0; x < kEnvW; ++x) {
+      int idx           = (y * kEnvW + x) * 3;
+      diff_ptr[idx + 0] = r;
+      diff_ptr[idx + 1] = g;
+      diff_ptr[idx + 2] = b;
+    }
+  }
+  auto diffuse_tex        = std::make_shared<Texture>();
+  diffuse_tex->_debugName = "procGradDiff";
+  txi->initTextureFromImage(diffuse_tex.get(), diffuse_image, false, false);
+  irrmaps->_filtenvDiffuseMap = diffuse_tex;
+
+  irrmaps->_brdfIntegrationMapGGX    = PBRMaterial::brdfIntegrationMap(ctx, "GGX");
+  irrmaps->_brdfIntegrationMapVelvet = PBRMaterial::brdfIntegrationMap(ctx, "GGXVELVET");
+  irrmaps->_brdfIntegrationMapGGXRIM = PBRMaterial::brdfIntegrationMap(ctx, "GGXRIM");
+  irrmaps->_brdfIntegrationMapBlinn  = PBRMaterial::brdfIntegrationMap(ctx, "BLINN");
+  irrmaps->_brdfIntegrationMapPhong  = PBRMaterial::brdfIntegrationMap(ctx, "PHONG");
+
+  return irrmaps;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 radiancemap_cache_ptr_t getRadianceMapCache() {
   static radiancemap_cache_ptr_t _instance;
   if (!_instance) {

--- a/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
+++ b/ork.lev2/src/gfx/renderer/NodeCompositor/pbr_common.cpp
@@ -150,58 +150,18 @@ radiancemaps_ptr_t CommonStuff::requestRadianceMapsSync(const AssetPath& texture
 
 ///////////////////////////////////////////////////////////////////////////////
 
-radiancemaps_ptr_t CommonStuff::makeRadianceMapsSolidColor(fvec3 color, Context* ctx) {
-  // Match the standard 10-level / pow(i/9, 0.5) layout produced by xir bakes
-  // so shaders and material parameters see a familiar roughness distribution.
-  constexpr int kNumRoughnessLevels = 10;
-  constexpr float kRoughnessPower   = 0.5f;
-  constexpr int kEnvW               = 16;
-  constexpr int kEnvH               = 8;
-
-  auto irrmaps                  = std::make_shared<RadianceMaps>();
-  irrmaps->_numRoughnessLevels  = kNumRoughnessLevels;
-  irrmaps->_specularRoughnessValues.resize(kNumRoughnessLevels);
-  for (int i = 0; i < kNumRoughnessLevels; ++i) {
-    irrmaps->_specularRoughnessValues[i] =
-        powf(float(i) / float(kNumRoughnessLevels - 1), kRoughnessPower);
-  }
-
-  auto txi = ctx->TXI();
-
-  irrmaps->_filtenvSpecularMapArray =
-      txi->createColorTextureV3Array(color, kEnvW, kEnvH, kNumRoughnessLevels);
-  irrmaps->_filtenvSpecularMapArray->_tex->_debugName = "procSolidSpec";
-
-  // NOTE: createColorTextureV3 declares BGR8 but writes RGB-ordered data,
-  // which swaps R and B on the GPU. Build the diffuse map via the
-  // RGB8-correct Image path instead.
-  auto diffuse_image = std::make_shared<Image>();
-  diffuse_image->initRGB8WithColor(kEnvW, kEnvH, color);
-  auto diffuse_tex         = std::make_shared<Texture>();
-  diffuse_tex->_debugName  = "procSolidDiff";
-  txi->initTextureFromImage(diffuse_tex.get(), diffuse_image, false, false);
-  irrmaps->_filtenvDiffuseMap = diffuse_tex;
-
-  irrmaps->_brdfIntegrationMapGGX    = PBRMaterial::brdfIntegrationMap(ctx, "GGX");
-  irrmaps->_brdfIntegrationMapVelvet = PBRMaterial::brdfIntegrationMap(ctx, "GGXVELVET");
-  irrmaps->_brdfIntegrationMapGGXRIM = PBRMaterial::brdfIntegrationMap(ctx, "GGXRIM");
-  irrmaps->_brdfIntegrationMapBlinn  = PBRMaterial::brdfIntegrationMap(ctx, "BLINN");
-  irrmaps->_brdfIntegrationMapPhong  = PBRMaterial::brdfIntegrationMap(ctx, "PHONG");
-
-  return irrmaps;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
 namespace {
 
-// Linear interpolation between (sorted) gradient stops at parameter t in [0,1].
+constexpr int   kProcNumRoughnessLevels = 10;
+constexpr float kProcRoughnessPower     = 0.5f;
+constexpr int   kProcEnvW               = 32;
+constexpr int   kProcEnvH               = 64;
+
 fvec3 sampleGradientAt(const std::vector<std::pair<float, fvec3>>& stops, float t) {
-  if (t <= stops.front().first)  return stops.front().second;
-  if (t >= stops.back().first)   return stops.back().second;
+  if (t <= stops.front().first) return stops.front().second;
+  if (t >= stops.back().first)  return stops.back().second;
   for (size_t i = 0; i + 1 < stops.size(); ++i) {
-    float t0 = stops[i].first;
-    float t1 = stops[i + 1].first;
+    float t0 = stops[i].first, t1 = stops[i + 1].first;
     if (t >= t0 && t <= t1) {
       float frac = (t1 > t0) ? (t - t0) / (t1 - t0) : 0.0f;
       return stops[i].second * (1.0f - frac) + stops[i + 1].second * frac;
@@ -210,171 +170,174 @@ fvec3 sampleGradientAt(const std::vector<std::pair<float, fvec3>>& stops, float 
   return stops.back().second;
 }
 
-// Solid-angle-weighted full-sphere average (used as the lerp target for
-// high-roughness specular slices, which converge toward an isotropic blur).
-fvec3 sphereAverage(const std::vector<std::pair<float, fvec3>>& stops, int n_samples = 64) {
-  fvec3 acc(0, 0, 0);
-  float w_sum = 0.0f;
-  for (int i = 0; i < n_samples; ++i) {
-    float v = (float(i) + 0.5f) / float(n_samples);
+// Solid-angle-weighted full-sphere average; lerp target for high-roughness slices.
+fvec3 sphereAverage(const std::vector<std::pair<float, fvec3>>& stops, int n = 64) {
+  fvec3 acc(0); float w_sum = 0.0f;
+  for (int i = 0; i < n; ++i) {
+    float v = (float(i) + 0.5f) / float(n);
     float w = sinf(v * float(PI));
     acc   = acc + sampleGradientAt(stops, v) * w;
     w_sum = w_sum + w;
   }
-  return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0, 0, 0);
+  return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0);
 }
 
-// Directional diffuse irradiance: cosine-weighted hemisphere integral of L(ω)
-// for a surface normal at polar angle theta_n from the up-axis. Because the
-// gradient is rotation-symmetric about the up-axis, the result depends only
-// on theta_n (no longitude variation). This is the standard Lambertian IBL
-// integral: E(n) = (1/π) ∫_hemi L(ω) max(0, n·ω) dω.
-fvec3 directionalDiffuse(
-    const std::vector<std::pair<float, fvec3>>& stops,
-    float theta_n) {
-  // n in the y-x plane, WLOG.
-  float nx = sinf(theta_n);
-  float ny = cosf(theta_n);
-
-  constexpr int kThetaSamples = 32;
-  constexpr int kPhiSamples   = 32;
-
-  fvec3 acc(0, 0, 0);
-  float w_sum = 0.0f;
-  for (int it = 0; it < kThetaSamples; ++it) {
-    float theta_w = (float(it) + 0.5f) / float(kThetaSamples) * float(PI);
-    float cy      = cosf(theta_w);
-    float cx      = sinf(theta_w); // also the solid-angle jacobian
-    fvec3 L       = sampleGradientAt(stops, theta_w / float(PI));
-    for (int ip = 0; ip < kPhiSamples; ++ip) {
-      float phi = (float(ip) + 0.5f) / float(kPhiSamples) * 2.0f * float(PI);
-      float ox  = cx * cosf(phi);
-      float dot = nx * ox + ny * cy;
+// Cosine-weighted hemisphere integral E(n) = (1/π) ∫ L(ω) max(0, n·ω) dω,
+// for a surface normal at polar angle theta_n. Rotation-symmetric env so the
+// result depends only on theta_n.
+fvec3 directionalDiffuse(const std::vector<std::pair<float, fvec3>>& stops, float theta_n) {
+  float nx = sinf(theta_n), ny = cosf(theta_n);
+  fvec3 acc(0); float w_sum = 0.0f;
+  constexpr int kT = 32, kP = 32;
+  for (int it = 0; it < kT; ++it) {
+    float theta_w = (float(it) + 0.5f) / float(kT) * float(PI);
+    float cy = cosf(theta_w), cx = sinf(theta_w);
+    fvec3 L = sampleGradientAt(stops, theta_w / float(PI));
+    for (int ip = 0; ip < kP; ++ip) {
+      float phi = (float(ip) + 0.5f) / float(kP) * 2.0f * float(PI);
+      float dot = nx * (cx * cosf(phi)) + ny * cy;
       if (dot > 0.0f) {
         float w = dot * cx;
-        acc     = acc + L * w;
-        w_sum   = w_sum + w;
+        acc   = acc + L * w;
+        w_sum = w_sum + w;
       }
     }
   }
-  return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0, 0, 0);
+  return (w_sum > 0.0f) ? acc * (1.0f / w_sum) : fvec3(0);
 }
 
-// Build an Image where each row's color is the gradient at that V, optionally
-// lerped toward `avg` to simulate roughness-induced blur.
-image_ptr_t buildGradientImage(
-    const std::vector<std::pair<float, fvec3>>& stops,
-    fvec3 avg,
-    float roughness_blend, // 0 = sharp gradient, 1 = uniform avg
-    int w,
-    int h) {
-  auto img             = std::make_shared<Image>();
-  img->_format         = EBufferFormat::RGB8;
+// Image filled with a per-row color via `row_color(v)`.
+template<typename F>
+image_ptr_t buildRowwiseImage(int w, int h, F&& row_color) {
+  auto img              = std::make_shared<Image>();
+  img->_format          = EBufferFormat::RGB8;
   img->_bytesPerChannel = 1;
   img->init(w, h, 3, 1);
-  auto outptr = (uint8_t*)img->_data->data();
+  auto p = (uint8_t*)img->_data->data();
   for (int y = 0; y < h; ++y) {
-    float v       = (h > 1) ? float(y) / float(h - 1) : 0.0f;
-    fvec3 c       = sampleGradientAt(stops, v);
-    fvec3 blended = c * (1.0f - roughness_blend) + avg * roughness_blend;
-    uint8_t r     = uint8_t(std::clamp(blended.x, 0.0f, 1.0f) * 255.0f);
-    uint8_t g     = uint8_t(std::clamp(blended.y, 0.0f, 1.0f) * 255.0f);
-    uint8_t b     = uint8_t(std::clamp(blended.z, 0.0f, 1.0f) * 255.0f);
+    float v = (h > 1) ? float(y) / float(h - 1) : 0.0f;
+    fvec3  c = row_color(v);
+    uint8_t r = uint8_t(std::clamp(c.x, 0.0f, 1.0f) * 255.0f);
+    uint8_t g = uint8_t(std::clamp(c.y, 0.0f, 1.0f) * 255.0f);
+    uint8_t b = uint8_t(std::clamp(c.z, 0.0f, 1.0f) * 255.0f);
     for (int x = 0; x < w; ++x) {
-      int idx          = (y * w + x) * 3;
-      outptr[idx + 0]  = r;
-      outptr[idx + 1]  = g;
-      outptr[idx + 2]  = b;
+      int idx = (y * w + x) * 3;
+      p[idx + 0] = r; p[idx + 1] = g; p[idx + 2] = b;
     }
   }
   return img;
 }
 
+// Uploads in-place: spec slices via updateTextureArraySlice (no
+// VulkanTextureObject realloc), diffuse via initTextureFromImage which
+// reuses the VkImage when format matches.
+void uploadRadianceMapsImages(
+    radiancemaps_ptr_t maps,
+    const std::vector<image_ptr_t>& spec_images,
+    image_ptr_t diffuse_image,
+    Context* ctx) {
+  OrkAssert(int(spec_images.size()) == maps->_numRoughnessLevels);
+  auto txi = ctx->TXI();
+  for (size_t i = 0; i < spec_images.size(); ++i) {
+    auto slice = maps->_filtenvSpecularMapArray->slice(i);
+    txi->updateTextureArraySlice(slice.get(), spec_images[i]);
+  }
+  txi->initTextureFromImage(maps->_filtenvDiffuseMap.get(), diffuse_image, false, false);
+}
+
 } // namespace
 
-radiancemaps_ptr_t CommonStuff::makeRadianceMapsGradient(
-    const std::vector<std::pair<float, fvec3>>& stops, Context* ctx) {
-  OrkAssert(!stops.empty());
+///////////////////////////////////////////////////////////////////////////////
 
-  constexpr int kNumRoughnessLevels = 10;
-  constexpr float kRoughnessPower   = 0.5f;
-  constexpr int kEnvW               = 32;
-  constexpr int kEnvH               = 64;
-
-  auto irrmaps                  = std::make_shared<RadianceMaps>();
-  irrmaps->_numRoughnessLevels  = kNumRoughnessLevels;
-  irrmaps->_specularRoughnessValues.resize(kNumRoughnessLevels);
-  for (int i = 0; i < kNumRoughnessLevels; ++i) {
-    irrmaps->_specularRoughnessValues[i] =
-        powf(float(i) / float(kNumRoughnessLevels - 1), kRoughnessPower);
+radiancemaps_ptr_t CommonStuff::makeProceduralRadianceMaps(Context* ctx) {
+  auto maps = std::make_shared<RadianceMaps>();
+  maps->_numRoughnessLevels = kProcNumRoughnessLevels;
+  maps->_specularRoughnessValues.resize(kProcNumRoughnessLevels);
+  for (int i = 0; i < kProcNumRoughnessLevels; ++i) {
+    maps->_specularRoughnessValues[i] =
+        powf(float(i) / float(kProcNumRoughnessLevels - 1), kProcRoughnessPower);
   }
 
-  fvec3 avg = sphereAverage(stops);
-
-  std::vector<image_ptr_t> spec_images;
-  spec_images.reserve(kNumRoughnessLevels);
-  for (int i = 0; i < kNumRoughnessLevels; ++i) {
-    float r = irrmaps->_specularRoughnessValues[i];
-    spec_images.push_back(buildGradientImage(stops, avg, r, kEnvW, kEnvH));
-  }
+  // Initial allocation — every slice and the diffuse share a single black
+  // image. Subsequent updates use updateTextureArraySlice / initTextureFromImage
+  // on these same texture objects (no descriptor-set churn).
+  auto black = std::make_shared<Image>();
+  black->initRGB8WithColor(kProcEnvW, kProcEnvH, fvec3(0));
 
   auto txi          = ctx->TXI();
   auto specular_arr = std::make_shared<TextureArray>();
-  specular_arr->_tex->_debugName = "procGradSpec";
+  specular_arr->_tex->_debugName = "procRadSpec";
   TextureArrayInitData TID;
-  TID._slices.resize(kNumRoughnessLevels);
-  for (int i = 0; i < kNumRoughnessLevels; ++i) {
+  TID._slices.resize(kProcNumRoughnessLevels);
+  for (int i = 0; i < kProcNumRoughnessLevels; ++i) {
     uint32_t usage_id = CrcString(FormatString("roughness_%d", i).c_str()).hashed();
-    TID._slices[i]    = TextureArrayInitSubItem{usage_id, spec_images[i]};
+    TID._slices[i]    = TextureArrayInitSubItem{usage_id, black};
   }
   txi->initTextureArray2DFromData(specular_arr.get(), TID);
-  // Equirectangular: U wraps (longitude seam), V clamps (no pole bleed
-  // across the wraparound when bilinear filtering at V=0 / V=1). Pairs with
-  // the envtools.i2 sampling using `1.0 - uv.y` instead of `-uv.y`.
-  specular_arr->_tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
-  specular_arr->_tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
-  specular_arr->_tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
-  txi->ApplySamplingMode(specular_arr->_tex.get());
-  irrmaps->_filtenvSpecularMapArray = specular_arr;
-
-  // Diffuse: per-row directional irradiance. The disk diffuse baker stores
-  // E for normal-DOWN at texel V=0 and normal-UP at V=1; we match that
-  // convention.
-  auto diffuse_image                = std::make_shared<Image>();
-  diffuse_image->_format            = EBufferFormat::RGB8;
-  diffuse_image->_bytesPerChannel   = 1;
-  diffuse_image->init(kEnvW, kEnvH, 3, 1);
-  auto diff_ptr = (uint8_t*)diffuse_image->_data->data();
-  for (int y = 0; y < kEnvH; ++y) {
-    float v       = (kEnvH > 1) ? float(y) / float(kEnvH - 1) : 0.0f;
-    float theta_n = (1.0f - v) * float(PI);  // V=0 → down, V=1 → up
-    fvec3 c       = directionalDiffuse(stops, theta_n);
-    uint8_t r     = uint8_t(std::clamp(c.x, 0.0f, 1.0f) * 255.0f);
-    uint8_t g     = uint8_t(std::clamp(c.y, 0.0f, 1.0f) * 255.0f);
-    uint8_t b     = uint8_t(std::clamp(c.z, 0.0f, 1.0f) * 255.0f);
-    for (int x = 0; x < kEnvW; ++x) {
-      int idx           = (y * kEnvW + x) * 3;
-      diff_ptr[idx + 0] = r;
-      diff_ptr[idx + 1] = g;
-      diff_ptr[idx + 2] = b;
-    }
+  // Equirectangular: U wraps, V clamps (no pole bleed at the V=0/V=1
+  // boundaries when bilinear-filtering near the poles).
+  for (auto* tex : {specular_arr->_tex.get()}) {
+    tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
+    tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
+    tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
+    txi->ApplySamplingMode(tex);
   }
+  maps->_filtenvSpecularMapArray = specular_arr;
+
   auto diffuse_tex        = std::make_shared<Texture>();
-  diffuse_tex->_debugName = "procGradDiff";
-  txi->initTextureFromImage(diffuse_tex.get(), diffuse_image, false, false);
+  diffuse_tex->_debugName = "procRadDiff";
+  txi->initTextureFromImage(diffuse_tex.get(), black, false, false);
   diffuse_tex->TexSamplingMode()._texAddrModeS = TextureAddressMode::WRAP;
   diffuse_tex->TexSamplingMode()._texAddrModeT = TextureAddressMode::CLAMP;
   diffuse_tex->TexSamplingMode()._texAddrModeR = TextureAddressMode::CLAMP;
   txi->ApplySamplingMode(diffuse_tex.get());
-  irrmaps->_filtenvDiffuseMap = diffuse_tex;
+  maps->_filtenvDiffuseMap = diffuse_tex;
 
-  irrmaps->_brdfIntegrationMapGGX    = PBRMaterial::brdfIntegrationMap(ctx, "GGX");
-  irrmaps->_brdfIntegrationMapVelvet = PBRMaterial::brdfIntegrationMap(ctx, "GGXVELVET");
-  irrmaps->_brdfIntegrationMapGGXRIM = PBRMaterial::brdfIntegrationMap(ctx, "GGXRIM");
-  irrmaps->_brdfIntegrationMapBlinn  = PBRMaterial::brdfIntegrationMap(ctx, "BLINN");
-  irrmaps->_brdfIntegrationMapPhong  = PBRMaterial::brdfIntegrationMap(ctx, "PHONG");
+  maps->_brdfIntegrationMapGGX    = PBRMaterial::brdfIntegrationMap(ctx, "GGX");
+  maps->_brdfIntegrationMapVelvet = PBRMaterial::brdfIntegrationMap(ctx, "GGXVELVET");
+  maps->_brdfIntegrationMapGGXRIM = PBRMaterial::brdfIntegrationMap(ctx, "GGXRIM");
+  maps->_brdfIntegrationMapBlinn  = PBRMaterial::brdfIntegrationMap(ctx, "BLINN");
+  maps->_brdfIntegrationMapPhong  = PBRMaterial::brdfIntegrationMap(ctx, "PHONG");
 
-  return irrmaps;
+  return maps;
+}
+
+void CommonStuff::updateRadianceMapsSolidColor(
+    radiancemaps_ptr_t maps, fvec3 color, Context* ctx) {
+  OrkAssert(maps && maps->_filtenvSpecularMapArray);
+  int W = int(maps->_filtenvSpecularMapArray->_width);
+  int H = int(maps->_filtenvSpecularMapArray->_height);
+  auto img = std::make_shared<Image>();
+  img->initRGB8WithColor(W, H, color);
+  std::vector<image_ptr_t> spec(maps->_numRoughnessLevels, img);
+  uploadRadianceMapsImages(maps, spec, img, ctx);
+}
+
+void CommonStuff::updateRadianceMapsGradient(
+    radiancemaps_ptr_t maps,
+    const std::vector<std::pair<float, fvec3>>& stops,
+    Context* ctx) {
+  OrkAssert(maps && maps->_filtenvSpecularMapArray);
+  OrkAssert(!stops.empty());
+  int W = int(maps->_filtenvSpecularMapArray->_width);
+  int H = int(maps->_filtenvSpecularMapArray->_height);
+  fvec3 avg = sphereAverage(stops);
+
+  // Specular slices: gradient at V, lerped toward sphere-average by the
+  // slice's roughness. Diffuse: per-row directional irradiance, V-flipped to
+  // match the disk diffuse baker convention (V=0 → down, V=1 → up).
+  std::vector<image_ptr_t> spec;
+  spec.reserve(maps->_specularRoughnessValues.size());
+  for (float r : maps->_specularRoughnessValues) {
+    spec.push_back(buildRowwiseImage(W, H, [&](float v) {
+      fvec3 c = sampleGradientAt(stops, v);
+      return c * (1.0f - r) + avg * r;
+    }));
+  }
+  auto diff = buildRowwiseImage(W, H, [&](float v) {
+    return directionalDiffuse(stops, (1.0f - v) * float(PI));
+  });
+  uploadRadianceMapsImages(maps, spec, diff, ctx);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds a `pbr_common` API for **procedural radiance maps** that can be populated in-place every frame without GPU resource churn — useful for dynamic skies, animated lighting, etc.

## New API (`pbr_common.h`)

  - `makeProceduralRadianceMaps(ctx)` — allocates the texture set (specular array + diffuse + cached BRDF LUTs), initial content black.
  - `updateRadianceMapsGradient(maps, stops, ctx)` — populates in place from  a list of `(v, rgb)` gradient stops. Reuses GPU textures (`updateTextureArraySlice` / `initTextureFromImage`) so descriptor-set caches stay valid; safe to call every frame. A single-stop gradient is the solid-color case (no separate API).

Spec slices are filtered toward the sphere-weighted average by roughness; diffuse is a cosine-weighted hemisphere integral evaluated per latitude.

## Supporting engine fixes

  - `fwdtools.i2`: `forward_lighting_ntex` now uses `albedo = ModAlbedo.xyz * modcolor` so per-vertex colors feed the albedo on the no-texture path (was being discarded).
  - `envtools.i2`: equirectangular V sampling uses `1.0 - V` instead of `fract(-V)`, removing the seam at V=0/V=1 that produced pole artifacts.
  - Radiance map textures (both procedural and disk-loaded) now use `T=CLAMP, R=CLAMP` so bilinear filtering doesn't wrap across the poles.
  - `rigid_primitive.inl`: `InstancedRigidPrimitiveDrawable::enqueueToRenderQueue` now calls `renderable.SetMatrix(fmtx4())` to reset the world matrix — `CallbackRenderable` lives in a pooled `fixedvector` that doesn't reset slots between frames, so instances inherited a stale world matrix from whichever renderable previously occupied the slot.

## Point light falloff

  - fwdtools.i2: plcalc_forward now uses a linear distance falloff — atten = max(0, 1 - d/R), no inverse-square term. radius becomes the cutoff distance in meters (light has no effect beyond it) and intensity the peak brightness at the source. The two are independent: radius scales the lit extent, doubling intensity scales peak brightness, neither affects the other. Previous behavior treated radius as an angular size for specular softening, leaving no way to control the lit extent.

## Test
```
ork.lev2/pyext/tests/renderer/primitives/procedural_pbr/procedural_envmaps.py`
```

A9×9 metallic/roughness sphere grid under three procedural environments (solid / static gradient / day-night cycle rebuilt every frame). Keys 1/2/3 to cycle modes.