### PR TITLE
Properly track and reshash  Shader state when any texture properties change.

### DIFF
--- a/ork.lev2/src/gfx/vulkan/headers/vk_pipeline.h
+++ b/ork.lev2/src/gfx/vulkan/headers/vk_pipeline.h
@@ -241,8 +241,16 @@ struct DescBinding {
 
 struct VkFxShaderPassState {
 
+  // bindParamTexture re-resolves Texture::_impl -> vktex every frame and
+  // writes the freshly resolved vktex here, so format-driven swaps in
+  // initTextureFromData (e.g. RGBA8_UNORM -> RGBA32_UINT for SH splat
+  // data) are picked up. On bind we compare the incoming vktex against
+  // the slot's existing value and zero _samplers_hash on change to
+  // force a fresh descriptor set. Per-context (not on the shared
+  // VkFxShaderUniformSampler) so multiple VkContexts don't stomp.
   std::unordered_map<fxparam_constptr_t, vktexobj_ptr_t> _textures_by_orkparam;
   std::unordered_map<fxparam_constptr_t, vkbuffer_ptr_t> _uniformbuffers_by_orkparam;
+  uint64_t _samplers_hash = 0; // 0 means dirty/needs recompute
 
   std::vector<VkParamSetItem> _pending_params;
   std::vector<uint8_t>        _pushdatabuffer;
@@ -252,7 +260,7 @@ struct VkFxShaderPassState {
 
   vkfxshaderpass_rawptr_t _shader = nullptr;
 
-  uint64_t samplersHash() const;
+  uint64_t samplersHash();
 };
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/ork.lev2/src/gfx/vulkan/vulkan_fxi_bindparam.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fxi_bindparam.cpp
@@ -90,8 +90,12 @@ bool VkFxInterface::_tryBindMergedResource(const FxShaderParam* hpar,
 
   switch (expected_type) {
     case VkMergedResourceBinding::Type::Sampler: {
-      auto vktex = resource_data.getShared<VulkanTextureObject>();
-      _current_shader_pass_state->_textures_by_orkparam[hpar] = vktex;
+      auto as_vktex = resource_data.getShared<VulkanTextureObject>();
+      auto& slot = _current_shader_pass_state->_textures_by_orkparam[hpar];
+      if (slot != as_vktex) {
+        slot = as_vktex;
+        _current_shader_pass_state->_samplers_hash = 0;
+      }
       break;
     }
     case VkMergedResourceBinding::Type::UniformBlock: {
@@ -717,7 +721,10 @@ void VkFxInterface::bindParamTexture(const FxShaderParam* hpar, const Texture* p
     //printf("Using default texture for tex<%p:%s> type<%d>\n", pTex, pTex->_debugName.c_str(), pTex->_texType);
   }
 
-  // Try to bind via merged resources
+  // Pass the resolved vk_tex (not pTex). bindParamTexture is called every
+  // frame, so re-resolving Texture::_impl here picks up any vktex swap
+  // (e.g. format change in initTextureFromData) before the descriptor
+  // set is built.
   _tryBindMergedResource(hpar, VkMergedResourceBinding::Type::Sampler, vk_tex);
 }
 

--- a/ork.lev2/src/gfx/vulkan/vulkan_fxi_buffer.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fxi_buffer.cpp
@@ -137,7 +137,12 @@ void VkFxInterface::bindStorageBuffer(const FxShaderStorageBlock* block,
   }
 
   // Store binding for later use when creating descriptor sets
-  block_state->_bound_buffer = vk_buffer;
+  if (block_state->_bound_buffer != vk_buffer) {
+    block_state->_bound_buffer = vk_buffer;
+    if (_current_shader_pass_state) {
+      _current_shader_pass_state->_samplers_hash = 0;
+    }
+  }
   block_state->_bound_ssbo   = buffer;
 }
 

--- a/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines.cpp
@@ -171,20 +171,28 @@ vkpipelinestate_rawptr_t VkFxInterface::_fetchPipeline(
 
 ///////////////////////////////////////////////////////////////////////////////
 
-uint64_t VkFxShaderPassState::samplersHash() const {
-  // Always recalculate to pick up changes in texture/SSBO bindings
+uint64_t VkFxShaderPassState::samplersHash() {
+  // Cached. bindParam* paths zero _samplers_hash when a binding changes,
+  // forcing a recompute on the next call. 0 is reserved for "dirty".
+  if (_samplers_hash != 0) {
+    return _samplers_hash;
+  }
   boost::Crc64 the_crc;
   the_crc.init();
-  for (auto& [param, tex] : _textures_by_orkparam) {
-    the_crc.accumulateItem(reinterpret_cast<uintptr_t>(tex.get()));
-    the_crc.accumulateItem(tex->_format_hash);
-    the_crc.accumulateItem(tex->_imgview_hash.result());
+  for (auto& [param, vktex] : _textures_by_orkparam) {
+    if (!vktex) continue;
+    the_crc.accumulateItem(reinterpret_cast<uintptr_t>(vktex.get()));
+    the_crc.accumulateItem(vktex->_format_hash);
+    the_crc.accumulateItem(vktex->_imgview_hash.result());
   }
   // Include storage buffer pointers so different SSBOs produce different cache keys
   for (auto* storage_state : _ordered_storage_states) {
     the_crc.accumulateItem(reinterpret_cast<uintptr_t>(storage_state->_bound_buffer.get()));
   }
-  return the_crc.finished();
+  uint64_t result = the_crc.finished();
+  if (result == 0) result = 1; // reserve 0 for "dirty"
+  _samplers_hash = result;
+  return _samplers_hash;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines_bind.cpp
+++ b/ork.lev2/src/gfx/vulkan/vulkan_fxi_pipelines_bind.cpp
@@ -433,11 +433,12 @@ vkdescriptorsetstate_ptr_t VulkanDescriptorSetCacheState::fetchDescriptorSetForP
     static std::unordered_map<int, VulkanTextureObject*> bound_textures;
     bound_textures.clear();
 
-    for (auto& [param, tex] : shader_state->_textures_by_orkparam) {
+    for (auto& [param, vktex] : shader_state->_textures_by_orkparam) {
       auto binding_it = vk_program->_merged_resource_bindings.find(param);
       if (binding_it != vk_program->_merged_resource_bindings.end()) {
         auto [set_id, binding_id] = binding_it->second;
-        bound_textures[binding_id] = tex.get();
+        if (!vktex) continue;
+        bound_textures[binding_id] = vktex.get();
       }
     }
 


### PR DESCRIPTION
Before samplerhash was not accounting for the unique state of a specific ShaderPassState causing it to not recognize when a rebuild of something related is necessary.