### PR TITLE
[pyext_reflection] handle bool in the reflection property __setattr__

### DIFF
--- a/ork.core/pyext/pyext_reflection.cpp
+++ b/ork.core/pyext/pyext_reflection.cpp
@@ -166,7 +166,11 @@ void pyinit_reflection(py::module& module_core) {
                     auto refprop = pitem.second;
                     auto propname = refprop->_name;
                     if(propname==key){
-                      if( auto as_int = dynamic_cast<ityped_int*>(refprop) ){
+                      if( auto as_bool = dynamic_cast<ityped_bool*>(refprop) ){
+                        as_bool->set(value.cast<bool>(),obj);
+                        return;
+                      }
+                      else if( auto as_int = dynamic_cast<ityped_int*>(refprop) ){
                         auto variant = proxy->_codec->decode(value);
                         as_int->set(variant.get<int>(),obj);
                         return;


### PR DESCRIPTION
(``PropertiesProxy.__setattr__`` in pyext_reflection.cpp) dispatched on
int / float / string / int_array, but had NO bool branch — so setting a
reflected ``bool`` directProperty from Python hit ``OrkAssert(false)``
("prop<X> unhandled type"). The GETTER (``.dict``) already handled bool;
only the setter was missing it.

This blocks the Python archetype-declaration path for ANY component with
a reflected bool. The .ecs JSON loader
handles bool fine, so scene-file archetypes were unaffected; only the
runtime ``SceneData.declareArchetype`` + ``cd.properties.X = bool`` path
crashed.

Add the bool branch first (before int — bool is a distinct ITyped<bool>),
casting the Python value directly with ``value.cast<bool>()``.
